### PR TITLE
ghc 7.10.1 Fixes 

### DIFF
--- a/Codec/TPTP/Base.hs
+++ b/Codec/TPTP/Base.hs
@@ -37,7 +37,10 @@ import Data.Functor.Classes() -- Import Eq,Ord,Show,Read orphan instances for Da
 import Util
 #endif
 
+#if !MIN_VERSION_base(4,8,0)
 deriving instance Data a => Data (Identity a)
+#endif
+
 #if MIN_VERSION_base(4,7,0)
 deriving instance Typeable Identity
 #else

--- a/Codec/TPTP/Base.hs
+++ b/Codec/TPTP/Base.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP, NoMonomorphismRestriction
-  , StandaloneDeriving 
+  , StandaloneDeriving
   , TypeSynonymInstances, FlexibleInstances, FlexibleContexts
   , UndecidableInstances, DeriveDataTypeable, GeneralizedNewtypeDeriving
   , OverlappingInstances, ScopedTypeVariables
@@ -15,7 +15,7 @@ module Codec.TPTP.Base where
 #define MIN_VERSION_base(a,b,c) 1
 #endif
 -- Assume we are using the newest versions when using ghci without cabal
-    
+
 import Codec.TPTP.QuickCheck
 import Control.Applicative
 import Control.Monad.Identity
@@ -36,7 +36,7 @@ import Data.Functor.Classes() -- Import Eq,Ord,Show,Read orphan instances for Da
 #if !MIN_VERSION_base(4,7,0)
 import Util
 #endif
-    
+
 deriving instance Data a => Data (Identity a)
 #if MIN_VERSION_base(4,7,0)
 deriving instance Typeable Identity
@@ -45,10 +45,10 @@ deriving instance Typeable1 Identity
 #endif
 
 -- * Basic undecorated formulae and terms
-                   
--- | Basic (undecorated) first-order formulae                   
+
+-- | Basic (undecorated) first-order formulae
 type Formula = F Identity
-    
+
 -- | Basic (undecorated) terms
 type Term = T Identity
 
@@ -56,7 +56,7 @@ type Term = T Identity
 
 -- | First-order formulae decorated with state
 type FormulaST s = F (State s)
-    
+
 -- | Terms decorated with state
 type TermST s = T (State s)
 
@@ -92,111 +92,111 @@ forgetTC (T t) = T . return $
 --
 -- @\(\.\<\=\>\.\) :: 'Formula' -> 'Formula' -> 'Formula'@
 (.<=>.) :: Pointed c => (F c) -> (F c) -> F c
-x .<=>. y = (F . point) $ BinOp  x (:<=>:) y  
-  
-            
+x .<=>. y = (F . point) $ BinOp  x (:<=>:) y
+
+
 -- | Implication
 (.=>.) :: Pointed c => (F c) -> (F c) -> F c
-x .=>.  y = (F . point) $ BinOp  x (:=>:)  y  
-            
+x .=>.  y = (F . point) $ BinOp  x (:=>:)  y
+
 -- | Reverse implication
 (.<=.) :: Pointed c => (F c) -> (F c) -> F c
-x .<=.  y = (F . point) $ BinOp  x (:<=:)  y  
-            
+x .<=.  y = (F . point) $ BinOp  x (:<=:)  y
+
 -- | Disjunction/OR
 (.|.) :: Pointed c => (F c) -> (F c) -> F c
-x .|.   y = (F . point) $ BinOp  x (:|:)   y  
-            
+x .|.   y = (F . point) $ BinOp  x (:|:)   y
+
 -- | Conjunction/AND
 (.&.) :: Pointed c => (F c) -> (F c) -> F c
-x .&.   y = (F . point) $ BinOp  x (:&:)   y  
-            
+x .&.   y = (F . point) $ BinOp  x (:&:)   y
+
 -- | XOR
 (.<~>.) :: Pointed c => (F c) -> (F c) -> F c
-x .<~>. y = (F . point) $ BinOp  x (:<~>:) y  
-            
+x .<~>. y = (F . point) $ BinOp  x (:<~>:) y
+
 -- | NOR
 (.~|.) :: Pointed c => (F c) -> (F c) -> F c
-x .~|.  y = (F . point) $ BinOp  x (:~|:)  y  
-            
-            
-            
+x .~|.  y = (F . point) $ BinOp  x (:~|:)  y
+
+
+
 -- | NAND
 (.~&.) :: Pointed c => (F c) -> (F c) -> F c
-x .~&.  y = (F . point) $ BinOp  x (:~&:)  y  
-            
-            
+x .~&.  y = (F . point) $ BinOp  x (:~&:)  y
+
+
 -- | Negation
 (.~.) :: Pointed c => (F c) -> F c
 (.~.) x = (F . point) $ (:~:) x
-          
+
 -- | Equality
 (.=.) :: Pointed c => (T c) -> (T c) -> F c
-x .=. y   = (F . point) $ InfixPred x (:=:)   y 
-            
+x .=. y   = (F . point) $ InfixPred x (:=:)   y
+
 -- | Inequality
 (.!=.) :: Pointed c => (T c) -> (T c) -> F c
-x .!=. y  = (F . point) $ InfixPred x (:!=:) y 
-            
+x .!=. y  = (F . point) $ InfixPred x (:!=:) y
+
 -- | Universal quantification
 for_all :: Pointed c => [V] -> (F c) -> F c
 for_all vars x = (F . point) $ Quant All vars x
-                 
+
 -- | Existential quantification
 exists :: Pointed c => [V] -> (F c) -> F c
 exists vars x = (F . point) $ Quant Exists vars x
-                
+
 -- | Predicate symbol application
 pApp :: Pointed c => AtomicWord -> [T c] -> F c
 pApp x args = (F . point) $ PredApp x args
-              
+
 -- | Variable
 var :: Pointed c => V -> T c
 var = (T . point) . Var
-      
+
 -- | Function symbol application (constants are encoded as nullary functions)
 fApp :: Pointed c => AtomicWord -> [T c] -> T c
 fApp x args = (T . point) $ FunApp x args
-              
+
 -- | Number literal
 numberLitTerm :: Pointed c => Rational -> T c
 numberLitTerm = (T . point) . NumberLitTerm
-                
--- | Double-quoted string literal, called /Distinct Object/ in TPTP's grammar 
+
+-- | Double-quoted string literal, called /Distinct Object/ in TPTP's grammar
 distinctObjectTerm :: Pointed c => String -> T c
 distinctObjectTerm = (T . point) . DistinctObjectTerm
-                     
+
 infixl 2  .<=>. ,  .=>. ,  .<=. ,  .<~>.
 infixl 3  .|. ,  .~|.
 infixl 4  .&. ,  .~&.
 infixl 5  .=. ,  .!=.
 
 -- * General decorated formulae and terms
-    
+
 -- | See <http://haskell.org/haskellwiki/Indirect_composite> for the point of the type parameters (they allow for future decorations, e.g. monadic subformulae). If you don't need decorations, you can just use 'Formula' and the wrapped constructors above.
-data Formula0 term formula = 
+data Formula0 term formula =
               BinOp formula BinOp formula -- ^ Binary connective application
             | InfixPred term InfixPred term -- ^ Infix predicate application (equalities, inequalities)
             | PredApp AtomicWord [term] -- ^ Predicate application
             | Quant Quant [V] formula -- ^ Quantified formula
             | (:~:) formula -- ^ Negation
               deriving (Eq,Ord,Show,Read,Data,Typeable)
-                       
-                       
+
+
 -- | See <http://haskell.org/haskellwiki/Indirect_composite> for the point of the type parameters (they allow for future decorations). If you don't need decorations, you can just use 'Term' and the wrapped constructors above.
 data Term0 term =
             Var V -- ^ Variable
           | NumberLitTerm Rational -- ^ Number literal
           | DistinctObjectTerm String -- ^ Double-quoted item
-          | FunApp AtomicWord [term] -- ^ Function symbol application (constants are encoded as nullary functions) 
+          | FunApp AtomicWord [term] -- ^ Function symbol application (constants are encoded as nullary functions)
             deriving (Eq,Ord,Show,Read,Data,Typeable)
-                     
-
-    
-    
 
 
--- | Binary formula connectives 
+
+
+
+
+-- | Binary formula connectives
 data BinOp =
     -- Please don't change the constructor names (the Show instance is significant)
                (:<=>:)  -- ^ Equivalence
@@ -212,25 +212,25 @@ data BinOp =
 -- | /Term -> Term -> Formula/ infix connectives
 data InfixPred =
     -- Please don't change the constructor names (the Show instance is significant)
-    (:=:) | (:!=:)         
+    (:=:) | (:!=:)
             deriving (Eq,Ord,Show,Read,Data,Typeable,Enum,Bounded)
-                       
+
 -- | Quantifier specification
 data Quant = All | Exists
               deriving (Eq,Ord,Show,Read,Data,Typeable,Enum,Bounded)
-                     
+
 -- * Formula Metadata
-    
+
 -- | A line of a TPTP file: Annotated formula, comment or include statement.
 type TPTP_Input = TPTP_Input_ Identity
 {-
     -- | Annotated formulae
     AFormula {
-      name :: AtomicWord 
-    , role :: Role 
-    , formula :: Formula 
-    , annotations :: Annotations 
-    }    
+      name :: AtomicWord
+    , role :: Role
+    , formula :: Formula
+    , annotations :: Annotations
+    }
     | Comment String
     | Include FilePath [AtomicWord]
 
@@ -247,18 +247,18 @@ forgetTIC (Comment s) = Comment s
 forgetTIC (Include p aws) = Include p aws
 
 -- | Generalized TPTP_Input
-data TPTP_Input_ c = 
+data TPTP_Input_ c =
    -- | Annotated formulae
    AFormula {
-     name :: AtomicWord 
-   , role :: Role 
+     name :: AtomicWord
+   , role :: Role
    , formula :: F c
-   , annotations :: Annotations 
-   }    
+   , annotations :: Annotations
+   }
    | Comment String
    | Include FilePath [AtomicWord]
 
-            
+
 deriving instance Eq (c (Formula0 (T c) (F c))) => Eq (TPTP_Input_ c)
 deriving instance Ord (c (Formula0 (T c) (F c))) => Ord (TPTP_Input_ c)
 deriving instance Show (c (Formula0 (T c) (F c))) => Show (TPTP_Input_ c)
@@ -274,14 +274,14 @@ instance Typeable1 c => Typeable (TPTP_Input_ c) where
   typeOf = mkTypeOfForRank2Kind "Codec.TPTP.Base" "TPTP_Input_"
 #endif
 
--- | Annotations about the formulas origin                   
+-- | Annotations about the formulas origin
 data Annotations = NoAnnotations | Annotations GTerm UsefulInfo
                   deriving (Eq,Ord,Show,Read,Data,Typeable)
-              
+
 -- | Misc annotations
 data UsefulInfo = NoUsefulInfo | UsefulInfo [GTerm]
                   deriving (Eq,Ord,Show,Read,Data,Typeable)
-                           
+
 -- | Formula roles
 newtype Role = Role { unrole :: String }
             deriving (Eq,Ord,Show,Read,Data,Typeable)
@@ -293,17 +293,17 @@ data GData = GWord AtomicWord
                  | GVar V
                  | GNumber Rational
                  | GDistinctObject String
-                 | GFormulaData String Formula 
+                 | GFormulaData String Formula
                    deriving (Eq,Ord,Show,Read,Data,Typeable)
-        
+
 -- | Metadata (the /general_term/ rule in TPTP's grammar)
-data GTerm = ColonSep GData GTerm                   
+data GTerm = ColonSep GData GTerm
            | GTerm GData
            | GList [GTerm]
              deriving (Eq,Ord,Show,Read,Data,Typeable)
-                     
 
-                   
+
+
 
 -- * Gathering free Variables
 
@@ -312,25 +312,25 @@ data GTerm = ColonSep GData GTerm
 
 -- instance FormulaOrTerm Identity Formula where
 --     elimFormulaOrTerm k _ x = k x
-                              
+
 -- instance FormulaOrTerm Identity Term where
 --     elimFormulaOrTerm _ k x = k x
-                              
+
 class FreeVars a where
     -- | Obtain the free variables from a formula or term
     freeVars :: a -> Set V
 
 -- | Universally quantify all free variables in the formula
 univquant_free_vars :: Formula -> Formula
-univquant_free_vars cnf = 
+univquant_free_vars cnf =
     case S.toList (freeVars cnf) of
       [] -> cnf
       vars -> for_all vars cnf
-             
+
 instance FreeVars Formula where
-    freeVars = foldF 
-               freeVars   
-               (\_ vars x -> S.difference (freeVars x) (S.fromList vars))                    
+    freeVars = foldF
+               freeVars
+               (\_ vars x -> S.difference (freeVars x) (S.fromList vars))
                (\x _ y -> (mappend `on` freeVars) x y)
                (\x _ y -> (mappend `on` freeVars) x y)
                (\_ args -> S.unions (fmap freeVars args))
@@ -346,21 +346,21 @@ instance FreeVars Term where
 --- Have the Arbitrary instances in this module to avoid orphan instances
 
 instance Arbitrary TPTP_Input
-    where arbitrary = frequency [(10,       
-                                    do 
+    where arbitrary = frequency [(10,
+                                    do
                                       x1 <- AtomicWord <$> arbLowerWord
                                       x2 <- arbitrary
                                       x3 <- arbitrary
                                       x4 <- arbitrary
                                       return (AFormula x1 x2 x3 x4))
-                                         
+
                                   , (1,
-                                    do 
+                                    do
                                       x1 <- arbPrintable
                                       return (Comment ("% "++x1))
                                   )
 
-                                  , (1, Include `fmap` arbLowerWord `ap` 
+                                  , (1, Include `fmap` arbLowerWord `ap`
                                          listOf arbitrary)
                                 ]
 
@@ -375,60 +375,60 @@ instance Arbitrary Annotations
                               return NoAnnotations
                             , Annotations `fmap` arbitrary `ap` arbitrary
                       ]
-                      
+
 instance Arbitrary UsefulInfo
     where arbitrary = oneof [
                               return NoUsefulInfo
-                             , do 
+                             , do
                                 x1 <- arbitrary
                                 return (UsefulInfo x1)
                       ]
-          
+
 instance Arbitrary Role
     where arbitrary = Role `fmap` arbLowerWord
-               
-               
+
+
 instance (Arbitrary a, Arbitrary b) => Arbitrary (Formula0 a b)
 
-    
+
     where arbitrary = sized go
 
            where
             go 0 = flip PredApp [] `fmap` arbitrary
-                   
-            go i =  
+
+            go i =
                 oneof [ do
                                   ileft <- choose (0,i-1)
                                   x1 <- resize ileft arbitrary
                                   x2 <- arbitrary
-                                  x3 <- resize (i - 1 - ileft) arbitrary 
+                                  x3 <- resize (i - 1 - ileft) arbitrary
                                   return (BinOp x1 x2 x3)
-                                         
-                      , do 
+
+                      , do
                                   x1 <- arbitrary
                                   x2 <- arbitrary
                                   x3 <- arbitrary
                                   return (InfixPred x1 x2 x3)
-                                         
+
                       , do
                                   x1 <- arbitrary
                                   x2 <- argsFreq vector
                                   return (PredApp x1 x2)
-                                            
+
                       , do
                                x1 <- arbitrary
                                x2 <- liftM2 (:) arbitrary (argsFreq (\nargs -> vectorOf nargs arbitrary))
                                x3 <- resize (i-1) arbitrary
                                return (Quant x1 x2 x3)
-                                           
+
                       , do
                                   x1 <- resize (i-1) arbitrary
                                   return ((:~:) x1)
                       ]
-                                          
+
 instance Arbitrary BinOp
     where arbitrary = elements
-                     
+
                              [ (:<=>:)
                              , (:=>:)
                              , (:<=:)
@@ -444,7 +444,7 @@ instance Arbitrary InfixPred
 
 instance Arbitrary Quant
     where arbitrary = elements [All,Exists]
-                      
+
 instance Arbitrary a => Arbitrary (Term0 a)
     where arbitrary = sized go
            where
@@ -453,25 +453,25 @@ instance Arbitrary a => Arbitrary (Term0 a)
             go 0 = frequency [ (2,Var <$> arbitrary), (1,FunApp `fmap` arbitrary `ap` return[] ) ]
 
             go i = oneof [
-                             do 
+                             do
                               x1 <- arbitrary
                               return (Var x1)
-                                     
-                           , arbNum NumberLitTerm 
-                             
-                                     
-                           , do 
+
+                           , arbNum NumberLitTerm
+
+
+                           , do
                               x1 <- arbPrintable
                               return (DistinctObjectTerm x1)
-                                     
-                           , do 
+
+                           , do
                               x1 <- arbitrary
-                              args <- argsFreq 
+                              args <- argsFreq
                                 (\nargs -> do
                                    parti <- arbPartition nargs (i-1)
                                    mapM (flip resize arbitrary) parti
                                 )
-                                                
+
                               return (FunApp x1 args)
                            ]
 
@@ -482,31 +482,31 @@ instance Arbitrary GData
                        go 0 = oneof [ fmap GWord arbitrary
                                     , fmap GVar arbitrary
                                     ]
-                    
-                       go i = 
-                           oneof 
+
+                       go i =
+                           oneof
                            [
                             GWord <$> arbitrary
-                                            
+
                            ,do
                               x1 <- arbLowerWord
-                              args <- argsFreq 
+                              args <- argsFreq
                                          (\nargs -> do
                                             parti <- arbPartition nargs (i-1)
                                             mapM (flip resize arbitrary) parti
                                          ) `suchThat` ((/=) [])
-                                          
+
                               return (GApp (AtomicWord x1) args)
-                                     
+
                            ,GVar <$> arbitrary
-                           ,arbNum GNumber 
-                                 
+                           ,arbNum GNumber
+
                            ,GDistinctObject <$> arbPrintable
                            ,GFormulaData `fmap` ((:) '$' `fmap` arbLowerWord) `ap` (sized (\n -> resize (n `div` 2) arbitrary))
                            ]
 
-                                 
-                                 
+
+
 instance Arbitrary GTerm
     where arbitrary = sized go
 
@@ -515,46 +515,46 @@ instance Arbitrary GTerm
 
                 go i =
                     oneof [
-                            do  
+                            do
                                   ileft <- choose(0,i-1)
                                   x1 <- resize ileft arbitrary
                                   x2 <- resize (i-1-ileft) arbitrary
                                   return (ColonSep x1 x2)
-                                         
+
                           , do
                                   x1 <- arbitrary
                                   return (GTerm x1)
-                                            
+
                           , do
-                                  args <- argsFreq 
+                                  args <- argsFreq
                                            (\nargs -> do
                                               parti <- arbPartition nargs (i-1)
                                               mapM (flip resize arbitrary) parti
                                            ) `suchThat` (/= [])
-                              
+
                                   return (GList args)
                        ]
-                            
--- | TPTP constant symbol\/predicate symbol\/function symbol identifiers (they are output in single quotes unless they are /lower_word/s). 
--- 
--- Tip: Use the @-XOverloadedStrings@ compiler flag if you don't want to have to type /AtomicWord/ to construct an 'AtomicWord' 
+
+-- | TPTP constant symbol\/predicate symbol\/function symbol identifiers (they are output in single quotes unless they are /lower_word/s).
+--
+-- Tip: Use the @-XOverloadedStrings@ compiler flag if you don't want to have to type /AtomicWord/ to construct an 'AtomicWord'
 newtype AtomicWord = AtomicWord String
     deriving (Eq,Ord,Show,Data,Typeable,Read,Monoid,IsString)
-                                         
+
 instance Arbitrary AtomicWord where
     arbitrary = frequency [  (5, AtomicWord <$> arbLowerWord)
                             ,(1, AtomicWord <$> arbPrintable)
                           ]
-                
+
 -- | Variable names
 newtype V = V String
     deriving (Eq,Ord,Show,Data,Typeable,Read,Monoid,IsString)
-                                         
+
 instance Arbitrary V where
     arbitrary = V <$> arbVar
-        
+
 -- * Fixed-point style decorated formulae and terms
-             
+
 -- | Formulae whose subexpressions are wrapped in the given type constructor @c@.
 --
 -- For example:
@@ -563,19 +563,19 @@ instance Arbitrary V where
 --
 -- - @c = 'Maybe'@: Formulae that may contain \"holes\"
 --
--- - @c = 'IORef'@: (Mutable) formulae with mutable subexpressions 
+-- - @c = 'IORef'@: (Mutable) formulae with mutable subexpressions
 newtype F c = F { runF :: c (Formula0 (T c) (F c)) }
-    
+
 -- | Terms whose subterms are wrapped in the given type constructor @c@
 newtype T c = T { runT :: c (Term0 (T c)) }
-             
+
 #define DI(X) deriving instance (X (c (Term0 (T c)))) => X (T c); deriving instance (X (c (Formula0 (T c) (F c)))) => X (F c)
-    
+
 DI(Eq)
 DI(Ord)
 DI(Show)
 DI(Read)
-  
+
 #if MIN_VERSION_base(4,7,0)
 deriving instance Typeable F
 deriving instance Typeable T
@@ -585,14 +585,14 @@ deriving instance (Typeable c, Data (c (Formula0 (T c) (F c)))) => Data (F c)
 #else
 instance Typeable1 c => Typeable (F c) where
     typeOf = mkTypeOfForRank2Kind "Codec.TPTP.Base" "F"
-    
+
 instance Typeable1 c => Typeable (T c) where
     typeOf = mkTypeOfForRank2Kind "Codec.TPTP.Base" "T"
 
 deriving instance (Typeable1 c, Data (c (Term0 (T c)))) => Data (T c)
 deriving instance (Typeable1 c, Data (c (Formula0 (T c) (F c)))) => Data (F c)
 #endif
-  
+
 -- * Utility functions
 
 unwrapF ::
@@ -619,7 +619,7 @@ foldFormula0 kneg kquant kbinop kinfix kpredapp f =
       BinOp x y z -> kbinop x y z
       InfixPred x y z -> kinfix x y z
       PredApp x y -> kpredapp x y
-                      
+
 foldTerm0 ::
                (String -> r)
              -> (Rational -> r)
@@ -644,7 +644,7 @@ foldF ::
          -> (T t -> InfixPred -> T t -> r) -- ^ Handle equality/inequality
          -> (AtomicWord -> [T t] -> r) -- ^ Handle predicate symbol application
          -> (F t -> r) -- ^ Handle formula
-         
+
 foldF kneg kquant kbinop kinfix kpredapp f = foldFormula0 kneg kquant kbinop kinfix kpredapp (unwrapF f)
 
 -- | Eliminate terms

--- a/Codec/TPTP/Diff.hs
+++ b/Codec/TPTP/Diff.hs
@@ -7,132 +7,132 @@
 {-# OPTIONS -Wall #-}
 
 module Codec.TPTP.Diff(Diffable(..),DiffResult(..),T0Diff,F0Diff,isSame,diffGenF,diffGenT,printSampleDiffs) where
-    
-    
+
+
 -- Warning: This module is a MESS (but it seems to work :)).
-    
+
 import Data.Generics
 import Test.QuickCheck hiding((.&.))
 import Codec.TPTP.Base
 import Codec.TPTP.Pretty
 import Text.PrettyPrint.ANSI.Leijen
 import Control.Monad.Identity
-    
-    
-    
 
-data DiffResult d = 
-          Same -- ^ Both arguments are the same. 
-        | SameHead d -- ^ The arguments are recursive expressions of the same form, but their subterms differ. Return a \"decorated\" term that shows where the differences are 
+
+
+
+data DiffResult d =
+          Same -- ^ Both arguments are the same.
+        | SameHead d -- ^ The arguments are recursive expressions of the same form, but their subterms differ. Return a \"decorated\" term that shows where the differences are
         | Differ d d -- ^ The arguments differ and are not of similar form (don't recurse)
         | DontCare
     deriving (Eq,Ord,Show,Data,Typeable,Read)
-                  
+
 isSame :: forall t. DiffResult t -> Bool
 isSame Same = True
 isSame _ = False
-             
+
 -- | Abstraction for diff'ing [predicate symbol|function symbol|gdata] applications
 -- Suggestive variable names for the case of function symbol applications
-handleAppExpr :: (Eq str) => 
-                (term -> term -> termfix DiffResult) -- ^ the diff function 
-                
-              -> (DiffResult a -> termfix DiffResult) -- ^ newtype wrapper 
+handleAppExpr :: (Eq str) =>
+                (term -> term -> termfix DiffResult) -- ^ the diff function
+
+              -> (DiffResult a -> termfix DiffResult) -- ^ newtype wrapper
               -> (termfix DiffResult -> DiffResult a) -- ^ newtype unwrapper
-                
+
               -> (str -> [termfix DiffResult] -> b) -- ^ Application expression constructor
-                
+
               -> str -- ^ First funsym
               -> [term] -- ^ First args
-                
+
               -> str -- ^ Second funsum
               -> [term] -- ^ Second args
-                
+
               -> DiffResult b
 handleAppExpr recFun newtypewrapper newtypeunwrapper constr x1 args1 x2 args2 =
                  -- recurse if heads and arities agree
                  case (x1==x2 && length args1 == length args2) of
-                   True -> 
+                   True ->
                        let
                            rec' = zipWith recFun args1 args2
                        in
                          case all (isSame . newtypeunwrapper) rec' of
                            True -> Same
-                           False -> SameHead (constr x1 rec') 
-                                  
-                   False -> 
+                           False -> SameHead (constr x1 rec')
+
+                   False ->
                        Differ (constr x1 (fmap (const . newtypewrapper $ DontCare) args1))
                               (constr x2 (fmap (const . newtypewrapper $ DontCare) args2))
-                              
-handleBinExpr :: 
+
+handleBinExpr ::
                  (Eq op) =>
                  (term -> term -> termfix DiffResult)
-                 
+
                  -> (DiffResult a -> termfix DiffResult) -- ^ NT wrapper
                  -> (termfix DiffResult -> DiffResult a) -- ^ NT unwrapepr
-                   
+
                  -> (termfix DiffResult -> op -> termfix DiffResult -> b) -- ^ constructor
-                   
+
                  -> term
                  -> op
                  -> term
-                   
+
                  -> term
                  -> op
                  -> term
-                   
+
                  -> DiffResult b
 handleBinExpr recFun newtypewrapper newtypeunwrapper constr l1 op1 r1 l2 op2 r2 =
     case op1==op2 of
-      True -> 
-          let 
+      True ->
+          let
               recl = recFun l1 l2
               recr = recFun r1 r2
           in
             case (newtypeunwrapper recl,newtypeunwrapper recr) of
               (Same,Same) -> Same
               (_,_)       -> SameHead (constr recl op1 recr)
-                            
+
       False ->
-          let dc = newtypewrapper DontCare 
-                   
+          let dc = newtypewrapper DontCare
+
           in Differ (constr dc op1 dc)
                     (constr dc op2 dc)
-                         
-handleUnary :: 
+
+handleUnary ::
                  (term -> term -> termfix DiffResult)
-                 
+
                  -> (DiffResult a -> termfix DiffResult) -- ^ NT wrapper
                  -> (termfix DiffResult -> DiffResult a) -- ^ NT unwrapepr
-                   
+
                  -> (termfix DiffResult -> b) -- ^ constructor
-                   
+
                  -> term
-                   
+
                  -> term
-                   
+
                  -> DiffResult b
-                   
+
 handleUnary recFun _ newtypeunwrapper constr r1 r2 =
-          let 
+          let
               rec' = recFun r1 r2
           in
             case newtypeunwrapper rec' of
               Same -> Same
               _    -> SameHead (constr rec')
-                            
 
-                 
-handleLeaf :: 
+
+
+handleLeaf ::
               (Eq a) =>
               (a -> d) -> a -> a -> DiffResult d
-handleLeaf constr x1 x2 = 
-    if x1==x2 
-    then Same 
+handleLeaf constr x1 x2 =
+    if x1==x2
+    then Same
     else Differ (constr x1) (constr x2)
-                   
-                   
-             
+
+
+
 -- runDiffTerm :: Term
 --                -> Term
 --                -> DiffResult (Term0 (T DiffResult))
@@ -141,19 +141,19 @@ handleLeaf constr x1 x2 =
 diffTerm :: Term -> Term -> T DiffResult
 diffTerm (T (Identity t1)) (T (Identity t2)) = T $
     case (t1,t2) of
-      (FunApp x1 args1,FunApp x2 args2) -> handleAppExpr diffTerm T runT FunApp x1 args1 x2 args2 
+      (FunApp x1 args1,FunApp x2 args2) -> handleAppExpr diffTerm T runT FunApp x1 args1 x2 args2
       (Var x1,Var x2) -> handleLeaf Var x1 x2
       (DistinctObjectTerm x1, DistinctObjectTerm x2) -> handleLeaf DistinctObjectTerm x1 x2
       (NumberLitTerm x1, NumberLitTerm x2) -> handleLeaf NumberLitTerm x1 x2
       _ -> let plug=plugSubterms (T DontCare) in Differ (plug t1) (plug t2)
-          
+
 plugSubterms :: forall a a1. a -> Term0 a1 -> Term0 a
 plugSubterms p t = case t of
                             FunApp x1 args -> FunApp x1 (fmap (const p) args)
                             DistinctObjectTerm x1 -> DistinctObjectTerm x1
                             NumberLitTerm x1 -> NumberLitTerm x1
                             Var x1 -> Var x1
-                                     
+
 plugSubformulae :: forall a formula a1 t.
                    a -> formula -> Formula0 a1 t -> Formula0 a formula
 plugSubformulae pt pf f = case f of
@@ -162,33 +162,33 @@ plugSubformulae pt pf f = case f of
                                BinOp _ b _ -> BinOp pf b pf
                                InfixPred _ b _ -> InfixPred pt b pt
                                (:~:) _ -> (:~:) pf
-                                                                  
-                                   
-          
+
+
+
 diffFormula :: Formula -> Formula -> F DiffResult
 diffFormula (F (Identity f1)) (F (Identity f2)) = F $
     case (f1,f2) of
       ( Quant q1 vars1 g1
-       ,Quant q2 vars2 g2) -> 
+       ,Quant q2 vars2 g2) ->
           case (q1==q2, vars1==vars2) of
-            (True,True) -> handleUnary diffFormula F runF (Quant q1 vars1) g1 g2   
-            _ -> Differ (Quant q1 vars1 (F DontCare)) 
-                       (Quant q2 vars2 (F DontCare)) 
-                           
+            (True,True) -> handleUnary diffFormula F runF (Quant q1 vars1) g1 g2
+            _ -> Differ (Quant q1 vars1 (F DontCare))
+                       (Quant q2 vars2 (F DontCare))
+
 
       ( BinOp l1 op1 r1
        ,BinOp l2 op2 r2 ) -> handleBinExpr diffFormula F runF BinOp l1 op1 r1 l2 op2 r2
-                                         
+
       ( InfixPred l1 op1 r1
        ,InfixPred l2 op2 r2 ) -> handleBinExpr diffTerm T runT InfixPred l1 op1 r1 l2 op2 r2
-                 
+
       ( (:~:) g1
        ,(:~:) g2 ) -> handleUnary diffFormula F runF (:~:) g1 g2
 
-      
+
       ( PredApp x1 args1
-       ,PredApp x2 args2 ) -> handleAppExpr diffTerm T runT PredApp x1 args1 x2 args2 
-                       
+       ,PredApp x2 args2 ) -> handleAppExpr diffTerm T runT PredApp x1 args1 x2 args2
+
       _ -> let plug=plugSubformulae (T DontCare) (F DontCare) in Differ (plug f1) (plug f2)
 
 
@@ -197,25 +197,25 @@ instance Show (T DiffResult) where
 
 instance Show (F DiffResult) where
     show (F f) = show f
-         
+
 type T0Diff = DiffResult (Term0 (T DiffResult))
 type F0Diff = DiffResult (Formula0 (T DiffResult) (F DiffResult))
-    
+
 
 wildcard :: AtomicWord
 wildcard = "_"
-                            
+
 instance Pretty (WithEnclosing T0Diff) where
     pretty = prettyHelper --(plugSubterms (fApp wildcard []))
- 
+
 instance Pretty (WithEnclosing F0Diff) where
     pretty = prettyHelper --(plugSubformulae (fApp wildcard []) (pApp wildcard []))
-       
+
 prettyHelper :: forall t.
                 (Pretty (WithEnclosing t)) =>
                 WithEnclosing (DiffResult t) -> Doc
-prettyHelper (WithEnclosing _ d) = 
-        let 
+prettyHelper (WithEnclosing _ d) =
+        let
             pwe = pretty . WithEnclosing EnclNothing
         in
           case d of
@@ -224,63 +224,63 @@ prettyHelper (WithEnclosing _ d) =
                  SameHead x -> blue . encloseSep (text "{ SameHead ") (text "}") semi $
                               [  pwe x
                               ]
-                                               
 
-                              
+
+
                  Differ x y -> red . encloseSep (text "{ Differ ") rbrace (text "; ") $
 
-                              [ pwe x 
+                              [ pwe x
                               , pwe y
                               ]
-                                                         
+
 deriving instance Pretty (T DiffResult)
 
 deriving instance Pretty (F DiffResult)
-         
+
 instance Pretty (WithEnclosing (T DiffResult)) where
-    pretty (WithEnclosing x (T y)) = pretty (WithEnclosing x y) 
-                                           
+    pretty (WithEnclosing x (T y)) = pretty (WithEnclosing x y)
+
 instance Pretty (WithEnclosing (F DiffResult)) where
-    pretty (WithEnclosing x (F y)) = pretty (WithEnclosing x y) 
-                                              
+    pretty (WithEnclosing x (F y)) = pretty (WithEnclosing x y)
+
 instance Pretty (T0Diff) where
     pretty = pretty . WithEnclosing EnclNothing
-    
+
 instance Pretty (F0Diff) where
     pretty = pretty . WithEnclosing EnclNothing
 
 -- instance Pretty (DiffResult (T DiffResult)) where
 --     pretty = pretty . WithEnclosing EnclNothing . T
-    
+
 -- instance Pretty (DiffResult (T DiffResult) (F DiffResult)) where
 --     pretty = pretty . WithEnclosing EnclNothing . F
-                                              
-                                  
+
+
 -- runFormulaDiff :: Formula
 --                   -> Formula
 --                   -> DiffResult
 --                        (Formula0 (T DiffResult) (F DiffResult))
 -- runFormulaDiff a b = runF (diffFormula a b)
-                     
+
 -- | Less random generator for generating formulae suitable for testing diff
 diffGenF :: Gen Formula
 diffGenF = sized go
             where
               go 0 = return $ pApp "Truth" []
-              go i = oneof 
+              go i = oneof
                   [
                    do
                      ileft <- choose (0,i-1)
                      liftM2 (.&.) (resize ileft diffGenF) (resize (i-1-ileft) diffGenF)
                   , let a=diffGenT in fmap (.=.) a `ap` a
                   ]
-           
+
 diffGenT :: Gen Term
 diffGenT = sized go
             where
               go 0 = elements[var "Z",fApp "1" []]
-                  
-              go i = oneof 
+
+              go i = oneof
                   [
                     let a=resize (i`div`3) diffGenT in fmap (fApp "g") (sequence [a,a,a])
                   , do
@@ -288,20 +288,20 @@ diffGenT = sized go
                      fmap (fApp "f") (sequence [resize ileft diffGenT,
                                                 resize (i-1-ileft) diffGenT])
                   ]
-             
-                     
+
+
 printSampleDiffs :: IO ()
 printSampleDiffs = do
   xs <- sample' diffGenF
   ys <- sample' diffGenF
 
-  let item x y = text (replicate 50 '=') 
+  let item x y = text (replicate 50 '=')
                  <$> pretty x
                  <$> text (replicate 40 '-')
                  <$> pretty y
                  <$> text (replicate 40 '-')
                  <$> pretty (diffFormula x y)
-  
+
   mapM_ (putStrLn . prettySimple . uncurry item) (zip xs ys)
 
 -- prop0 :: Formula -> Formula -> Property
@@ -311,10 +311,10 @@ printSampleDiffs = do
 --                                   (pApp "foo" [] .&. f2)
 
 --               in collect res $ True
-                 
+
 --                  -- case res of
---                  --   SameHead ((F Same) :&: 
---                  --            (F (Differ f1  
+--                  --   SameHead ((F Same) :&:
+--                  --            (F (Differ f1
 
 instance Functor DiffResult where
     fmap f d = case d of

--- a/Codec/TPTP/Diff.hs
+++ b/Codec/TPTP/Diff.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE NoMonomorphismRestriction, RecordWildCards
+{-# LANGUAGE CPP, NoMonomorphismRestriction, RecordWildCards
   , StandaloneDeriving, MultiParamTypeClasses, FunctionalDependencies
   , TypeSynonymInstances, FlexibleInstances, FlexibleContexts
   , UndecidableInstances, DeriveDataTypeable, GeneralizedNewtypeDeriving
@@ -10,6 +10,10 @@ module Codec.TPTP.Diff(Diffable(..),DiffResult(..),T0Diff,F0Diff,isSame,diffGenF
 
 
 -- Warning: This module is a MESS (but it seems to work :)).
+
+#if MIN_VERSION_base(4,8,0)
+import Prelude hiding ((<$>))
+#endif
 
 import Data.Generics
 import Test.QuickCheck hiding((.&.))

--- a/Codec/TPTP/Import.hs
+++ b/Codec/TPTP/Import.hs
@@ -22,4 +22,3 @@ parseWithComment = parseTPTPwithComment . map snd . alexScanTokens
 
 parseWithCommentFile :: FilePath -> IO [TPTP_Input_C]
 parseWithCommentFile x = parseWithComment `fmap` readFile x
-

--- a/Codec/TPTP/Pretty.hs
+++ b/Codec/TPTP/Pretty.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE NoMonomorphismRestriction, RecordWildCards
+{-# LANGUAGE CPP, NoMonomorphismRestriction, RecordWildCards
   , StandaloneDeriving
   , TypeSynonymInstances, FlexibleInstances, FlexibleContexts
   , UndecidableInstances, DeriveDataTypeable, GeneralizedNewtypeDeriving
@@ -9,6 +9,10 @@
 
 -- | Mainly just 'Pretty' instances
 module Codec.TPTP.Pretty(prettySimple,WithEnclosing(..),Enclosing(..)) where
+
+#if MIN_VERSION_base(4,8,0)
+import Prelude hiding ((<$>))
+#endif
 
 import Codec.TPTP.Base
 import Codec.TPTP.Export

--- a/Codec/TPTP/QuickCheck.hs
+++ b/Codec/TPTP/QuickCheck.hs
@@ -6,7 +6,7 @@
   #-}
 {-# OPTIONS -Wall #-}
 module Codec.TPTP.QuickCheck where
-    
+
 import Test.QuickCheck
 import Control.Monad
 import Control.Applicative
@@ -23,10 +23,10 @@ argsFreq f = frequency [ (10,f 0)
                         , (2 ,f 4)
                         , (1, f 15)
                         ]
-              
+
 arbVar :: Gen [Char]
-arbVar = liftM2 (:) (elements "WXZY") (show <$> choose(1::Int,3))  
-        
+arbVar = liftM2 (:) (elements "WXZY") (show <$> choose(1::Int,3))
+
 -- sorry I don't feel like calculating this distribution deductively at the moment ;)
 -- | Return random partition of n items into the given number of buckets if buckets>0
 --
@@ -41,14 +41,14 @@ arbPartition buckets n = do
         do arrr <- newArray (1,buckets) 0
            forM_ choices (\bucket -> writeArray arrr bucket . succ =<< readArray arrr bucket)
            return arrr
-  return $ elems uarray 
+  return $ elems uarray
 
 arbPrintable :: Gen [Char]
 arbPrintable = listOf (arbitrary `suchThat` printable)
-               
+
 printable :: Char -> Bool
 printable x = isAscii x && isPrint x --isDigit x || isLetter x || x `elem` " _+!@#$%^&*()[]{}-=?.,;'\":/\\"
-    
+
 arbLowerWord :: Gen String
 arbLowerWord = (:) `fmap` elements ['a'..'z'] `ap` listOf (elements (['a'..'z']++['A'..'Z']++"_"))
 
@@ -56,7 +56,7 @@ arbLowerWord = (:) `fmap` elements ['a'..'z'] `ap` listOf (elements (['a'..'z']+
 arbUpperWord :: Gen String
 arbUpperWord = (:) `fmap` elements ['A'..'Z'] `ap` listOf (elements (['a'..'z']++['A'..'Z']++"_"))
 
-               
+
 arbNum :: forall a a1. (Arbitrary a, Num a) => (a -> a1) -> Gen a1
 arbNum f =
     frequency [(1,fmap f arbitrary)

--- a/Parser.y
+++ b/Parser.y
@@ -1,6 +1,6 @@
 {
 module Parser where
-    
+
 import Data.Char
 import Data.Data
 import Data.Ratio
@@ -16,8 +16,8 @@ import Control.Monad.Identity
 
 %name parseTPTP
 %tokentype { Token }
-%error { 
-          
+%error {
+
           ((\xs -> case xs of
                     xs -> error ("Parse error, pos: "++show (take 25 xs))))
        }
@@ -67,32 +67,32 @@ import Control.Monad.Identity
 
  comment            { CommentToken $$ }
 
-     
-%% 
+
+%%
 
 TPTP_file  :: {[TPTP_Input_ c]}
 TPTP_file  : {[]} | TPTP_input TPTP_file  {$1 : $2}
-           
+
 TPTP_input  :: {TPTP_Input_ c}
-TPTP_input  : annotated_formula  {$1} 
+TPTP_input  : annotated_formula  {$1}
              | include  { $1 }
              | comment { Comment $1 }
 
 annotated_formula  :: {TPTP_Input_ c}
-annotated_formula  :  fof_annotated  {$1} 
+annotated_formula  :  fof_annotated  {$1}
                     | cnf_annotated  {$1}
 
 fof_annotated  :: {TPTP_Input_ c}
 fof_annotated  : fof lp name  comma formula_role  comma fof_formula  annotations  rp dot
        { AFormula        $3               $5                $7           $8 }
-                
+
 cnf_annotated  :: {TPTP_Input_ c}
 cnf_annotated  : cnf lp name  comma formula_role  comma cnf_formula  annotations  rp dot
        { AFormula          $3              $5  (univquant_free_vars $7) $8 }
-       
-       
+
+
 annotations  :: { Annotations }
-annotations  :  comma source optional_info  { Annotations $2 $3 } 
+annotations  :  comma source optional_info  { Annotations $2 $3 }
     | { NoAnnotations }
 
 formula_role  :: {Role}
@@ -102,44 +102,44 @@ formula_role  : lower_word_ { Role $1 }
 fof_formula  :: {F c}
 fof_formula  : binary_formula  { $1 }
               | unitary_formula  { $1 }
-      
+
 binary_formula  :: {F c}
 binary_formula  : nonassoc_binary  {$1}
                  | assoc_binary  {$1}
-                 
+
 nonassoc_binary  :: {F c}
-nonassoc_binary  : unitary_formula  binary_connective  unitary_formula 
+nonassoc_binary  : unitary_formula  binary_connective  unitary_formula
                   { $2 $1 $3 }
 
-                  
+
 assoc_binary  :: {F c}
 assoc_binary  : or_formula  { $1 }
                | and_formula  { $1 }
-    
-                 
+
+
 or_formula  :: {F c}
 or_formula  : unitary_formula   vline  unitary_formula  more_or_formula
                { L.foldl (.|.) ($1 .|. $3) $4 }
-             
+
 more_or_formula  :: {[F c]}
-more_or_formula  : {[]} | vline  unitary_formula more_or_formula 
+more_or_formula  : {[]} | vline  unitary_formula more_or_formula
                   { $2 : $3 }
-                  
+
 and_formula  :: {F c}
 and_formula  : unitary_formula  ampersand unitary_formula  more_and_formula
                { L.foldl (.&.) ($1 .&. $3) $4 }
 
 
 more_and_formula  :: {[F c]}
-more_and_formula  : {[]} | ampersand unitary_formula more_and_formula 
+more_and_formula  : {[]} | ampersand unitary_formula more_and_formula
                    { $2 : $3 }
-                   
+
 unitary_formula  :: {Formula}
 unitary_formula  :  quantified_formula  {$1}
                   | unary_formula       {$1}
                   | atomic_formula      {$1}
                   | lp fof_formula  rp  {$2}
-                   
+
 quantified_formula  :: {F c}
 quantified_formula  : quantifier  lbra variable_list  rbra colon unitary_formula
                      { $1 $3 $6 }
@@ -151,7 +151,7 @@ variable_list  : variable  { [$1] }
 unary_formula  :: {F c}
 unary_formula  : unary_connective  unitary_formula  { $1 $2 }
                 | fol_infix_unary  { $1 }
-   
+
 
 
 
@@ -163,20 +163,20 @@ cnf_formula  :: {F c}
 cnf_formula  :  lp disjunction  rp  { $2 }
               | disjunction  { $1 }
 
-                
+
 disjunction  :: {F c}
-disjunction  : literal  more_disjunction 
+disjunction  : literal  more_disjunction
               { L.foldl (.|.) $1 $2 }
-              
+
 more_disjunction  :: {[F c]}
-more_disjunction  :  {[]} | vline  literal more_disjunction 
+more_disjunction  :  {[]} | vline  literal more_disjunction
                    { $2 : $3 }
 
 literal  :: {Formula}
-literal  : atomic_formula  {$1} 
-          | tilde atomic_formula  { (.~.) $2} 
+literal  : atomic_formula  {$1}
+          | tilde atomic_formula  { (.~.) $2}
           | fol_infix_unary  {$1}
-          
+
 fol_infix_unary  :: {F c}
 fol_infix_unary  : term  infix_inequality  term  { $2 $1 $3 }
 
@@ -191,93 +191,93 @@ binary_connective  : iff { (.<=>.) }
                     | nor  { (.~|.) }
                     | nand { (.~&.) }
 
---- assoc_connective  : vline  
+--- assoc_connective  : vline
 ---                    | ampersand
-                   
+
 unary_connective  :: {Formula -> Formula}
 unary_connective  : tilde { (.~.) }
 
--- defined_type  :== atomic_defined_word 
+-- defined_type  :== atomic_defined_word
 
 -- defined_type  :== $oType | $o | $iType | $i | $tType | $real | $int
--- system_type  :== atomic_system_word 
+-- system_type  :== atomic_system_word
 
-atomic_formula  :: {F c} 
+atomic_formula  :: {F c}
 atomic_formula  :  plain_atomic_formula    {$1}
                  | defined_atomic_formula  {$1}
                  | system_atomic_formula   {$1}
-                 
+
 
 plain_atomic_formula  :: {F c}
 plain_atomic_formula  : plain_term  { fApp2pApp $1 }
 
--- plain_atomic_formula  :== proposition  | predicate  lp arguments  rp 
--- proposition  :== predicate 
--- predicate  :== atomic_word 
+-- plain_atomic_formula  :== proposition  | predicate  lp arguments  rp
+-- proposition  :== predicate
+-- predicate  :== atomic_word
 
 defined_atomic_formula  :: {F c}
-defined_atomic_formula  :  defined_plain_formula  {$1} 
+defined_atomic_formula  :  defined_plain_formula  {$1}
                          | defined_infix_formula  {$1}
-                         
+
 defined_plain_formula  :: {F c}
 defined_plain_formula  : defined_plain_term  {fApp2pApp $1}
-                        
---defined_plain_formula  :== defined_prop  | defined_pred  lp arguments  rp 
---defined_prop  :== atomic_defined_word 
+
+--defined_plain_formula  :== defined_prop  | defined_pred  lp arguments  rp
+--defined_prop  :== atomic_defined_word
 --defined_prop  :== $true | $false
---defined_pred  :== atomic_defined_word 
+--defined_pred  :== atomic_defined_word
 --defined_pred  :== $equal
 
 
 defined_infix_formula  :: {F c}
 defined_infix_formula  : term  defined_infix_pred  term  { $2 $1 $3 }
-                        
-defined_infix_pred :: { T c -> T c -> F c } 
+
+defined_infix_pred :: { T c -> T c -> F c }
 defined_infix_pred  : infix_equality  { $1 }
 
 infix_equality  :: { Term -> Term -> Formula }
 infix_equality  : equals { (.=.) }
-                
+
 infix_inequality  :: { Term -> Term -> Formula }
 infix_inequality  : nequals { (.!=.) }
 
-system_atomic_formula  :: {F c} 
+system_atomic_formula  :: {F c}
 system_atomic_formula  : system_term  {fApp2pApp $1}
 
-term  :: {Term}                        
+term  :: {Term}
 term  :  function_term  {$1}
        | variable       {var $1}
-       
-function_term  :: {Term}                        
-function_term  : plain_term {$1} 
+
+function_term  :: {Term}
+function_term  : plain_term {$1}
                 | defined_term  {$1}
                 | system_term {$1}
 
-plain_term  :: {Term}                        
+plain_term  :: {Term}
 plain_term  :  constant                  {fApp $1 []}
              | functor  lp arguments  rp {fApp $1 $3}
-              
+
 constant  :: {AtomicWord}
 constant  : functor {$1}
 
 functor  :: {AtomicWord}
 functor  : atomic_word {$1}
 
-defined_term  :: {Term}                        
-defined_term  : defined_atom {$1} 
+defined_term  :: {Term}
+defined_term  : defined_atom {$1}
                | defined_atomic_term {$1}
-               
 
-defined_atom  :: {Term}                        
-defined_atom  : number {numberLitTerm $1} 
+
+defined_atom  :: {Term}
+defined_atom  : number {numberLitTerm $1}
                | distinct_object {distinctObjectTerm (stripQuotes '"' $1)}
-                 
-defined_atomic_term :: {Term}                
+
+defined_atomic_term :: {Term}
 defined_atomic_term  : defined_plain_term {$1}
-                      
-defined_plain_term  :: {Term}                        
-defined_plain_term  : defined_constant {fApp (AtomicWord $1) []} 
-                     | defined_functor  lp arguments  rp {fApp (AtomicWord $1) $3} 
+
+defined_plain_term  :: {Term}
+defined_plain_term  : defined_constant {fApp (AtomicWord $1) []}
+                     | defined_functor  lp arguments  rp {fApp (AtomicWord $1) $3}
 
 defined_constant  :: {String}
 defined_constant  : defined_functor {$1}
@@ -287,16 +287,16 @@ defined_functor  :: {String}
 defined_functor  : atomic_defined_word {$1}
 -- defined_functor  :==
 
-system_term  :: {Term} 
+system_term  :: {Term}
 system_term  :  system_constant  {fApp (AtomicWord $1) []}
-              | system_functor  lp arguments  rp {fApp (AtomicWord $1) $3} 
+              | system_functor  lp arguments  rp {fApp (AtomicWord $1) $3}
 
-system_constant  :: {String}                
+system_constant  :: {String}
 system_constant  : system_functor  {$1}
 
-system_functor  :: {String}                
+system_functor  :: {String}
 system_functor  : atomic_system_word {$1}
-                 
+
 variable  :: {V}
 variable  : upper_word {V $1}
 
@@ -304,111 +304,111 @@ arguments  :: {[T c]}
 arguments  : term  {[$1]}
             | term  comma arguments  { $1 : $3 }
 
-source  :: {GTerm} 
+source  :: {GTerm}
 source  : general_term  {$1}
 
 -- source  :== dag_source  | internal_source  | external_source  | unknown
 
--- dag_source  :== name  | inference_record 
+-- dag_source  :== name  | inference_record
 
--- inference_record  :== inference lp inference_rule  comma useful_info  comma  [parent_list ] rp 
--- inference_rule  :== atomic_word 
--- parent_list  :== parent_info  | parent_info  comma parent_list 
--- parent_info  :== source parent_details 
--- parent_details  :== :general_list  | null 
--- internal_source  :== introduced lp intro_type optional_info  rp 
+-- inference_record  :== inference lp inference_rule  comma useful_info  comma  [parent_list ] rp
+-- inference_rule  :== atomic_word
+-- parent_list  :== parent_info  | parent_info  comma parent_list
+-- parent_info  :== source parent_details
+-- parent_details  :== :general_list  | null
+-- internal_source  :== introduced lp intro_type optional_info  rp
 -- intro_type  :== definition | axiom_of_choice | tautology | assumption
--- external_source  :== file_source  | theory  | creator_source 
--- file_source  :== file lp file_name file_info  rp 
--- file_info  :==  comma name  | null 
--- theory  :== theory lp theory_name optional_info  rp 
+-- external_source  :== file_source  | theory  | creator_source
+-- file_source  :== file lp file_name file_info  rp
+-- file_info  :==  comma name  | null
+-- theory  :== theory lp theory_name optional_info  rp
 -- theory_name  :== equality | ac
--- creator_source  :== creator lp creator_name optional_info  rp 
--- creator_name  :== atomic_word 
+-- creator_source  :== creator lp creator_name optional_info  rp
+-- creator_name  :== atomic_word
 
-optional_info  :: {UsefulInfo} 
+optional_info  :: {UsefulInfo}
 optional_info  :  comma useful_info  {$2} |  {NoUsefulInfo}
-    
+
 useful_info  :: { UsefulInfo }
 useful_info  : general_list  {UsefulInfo $1}
 
 -- useful_info  :== [] | [info_items ]
--- info_items  :== info_item  | info_item  comma info_items 
--- info_item  :== formula_item  | inference_item  | general_function 
--- formula_item  :== description_item  | iquote_item 
--- description_item  :== description lp atomic_word  rp 
--- iquote_item  :== iquote lp atomic_word  rp 
--- inference_item  :== inference_status  | assumptions_record  | refutation 
--- inference_status  :== status lp status_value  rp  | inference_info 
+-- info_items  :== info_item  | info_item  comma info_items
+-- info_item  :== formula_item  | inference_item  | general_function
+-- formula_item  :== description_item  | iquote_item
+-- description_item  :== description lp atomic_word  rp
+-- iquote_item  :== iquote lp atomic_word  rp
+-- inference_item  :== inference_status  | assumptions_record  | refutation
+-- inference_status  :== status lp status_value  rp  | inference_info
 -- status_value  :== suc | unp | sap | esa | sat | fsa | thm | eqv | tac | wec | eth | tau | wtc | wth | cax | sca | tca | wca |cup | csp | ecs | csa | cth | ceq | unc | wcc | ect | fun | uns | wuc | wct | scc | uca | noc
 
--- inference_info  :== inference_rule  lp atomic_word  comma general_list  rp 
--- assumptions_record  :== assumptions lp [name_list ] rp 
--- refutation  :== refutation lp file_source  rp 
+-- inference_info  :== inference_rule  lp atomic_word  comma general_list  rp
+-- assumptions_record  :== assumptions lp [name_list ] rp
+-- refutation  :== refutation lp file_source  rp
 
 include :: {TPTP_Input}
-include  : include_ lp file_name formula_selection  rp dot { Include $3 $4 } 
+include  : include_ lp file_name formula_selection  rp dot { Include $3 $4 }
 
 formula_selection  :: {[AtomicWord]}
-formula_selection  :  comma lbra name_list  rbra { $3 } 
+formula_selection  :  comma lbra name_list  rbra { $3 }
                     |   { [] }
 
 name_list  :: {[AtomicWord]}
 name_list  : name  {[$1]}
             | name  comma name_list  { $1 : $3 }
 
-              
+
 general_term  :: {GTerm}
-general_term  :  general_data  {GTerm $1} 
-               | general_data colon general_term  {ColonSep $1 $3} 
-               | general_list {GList $1} 
+general_term  :  general_data  {GTerm $1}
+               | general_data colon general_term  {ColonSep $1 $3}
+               | general_list {GList $1}
 
 general_data  :: {GData}
-general_data  :  atomic_word  { GWord $1 } 
-               | atomic_word  lp general_terms  rp { GApp $1 $3 }  
+general_data  :  atomic_word  { GWord $1 }
+               | atomic_word  lp general_terms  rp { GApp $1 $3 }
                | variable  { GVar $1 }
                | number  { GNumber $1 }
                | distinct_object { GDistinctObject (stripQuotes '"' $1) }
                | formula_data  { $1 }
-               
+
 formula_data :: {GData}
 formula_data  : dollar_word lp fof_formula  rp { GFormulaData $1 $3 }
               -- too ambiguous | dollar_word lp cnf_formula  rp { GFormulaData $1 $3 }
-                
+
 general_list  :: {[GTerm]}
 general_list  : lbra rbra {[]}
                | lbra general_terms  rbra {$2}
-               
+
 general_terms  :: {[GTerm]}
-general_terms  :  general_term  {[$1]} 
+general_terms  :  general_term  {[$1]}
                 | general_term  comma general_terms  {$1 : $3}
 
 name  :: {AtomicWord}
 name  : atomic_word  {$1}
        | unsigned_integer {AtomicWord(show $1)}
-         
-atomic_word  :: {AtomicWord}       
+
+atomic_word  :: {AtomicWord}
 atomic_word  : lower_word_ {AtomicWord $1}
               | single_quoted{AtomicWord (stripQuotes '\'' $1)}
-                
-atomic_defined_word  :: {String}              
+
+atomic_defined_word  :: {String}
 atomic_defined_word  : dollar_word{$1}
-                      
-atomic_system_word  :: {String}              
+
+atomic_system_word  :: {String}
 atomic_system_word  : dollar_dollar_word{$1}
 
 number  :: {Rational} -- maybe keep track of the number type that was actually parsed
-number  : integer {fromIntegral $1} | rational {$1} | real {$1}  
+number  : integer {fromIntegral $1} | rational {$1} | real {$1}
 
 integer :: {Integer}
 integer : signed_integer {$1} | unsigned_integer {$1}
 
-rational :: {Rational} 
-rational : integer tok_slash unsigned_integer {$1 % $3} 
-    
-file_name  :: {String}              
+rational :: {Rational}
+rational : integer tok_slash unsigned_integer {$1 % $3}
+
+file_name  :: {String}
 file_name  : single_quoted {stripQuotes '\'' $1}
-            
+
 lower_word_ :: {String}
 lower_word_ : lower_word {$1} | fof {"fof"} | cnf {"cnf"} | include_ {"include"} -- "fof" is a perfectly cromulent lower_word, but it is interpreted as a "fof" token
 
@@ -489,7 +489,7 @@ real               : tok_real                comment_list { $1 }
 
 comment_list :: {[String]}
 comment_list : {[]} | comment comment_list { $1 : $2 }
-       
+
 {
 
 stripQuotes which (x:xs) = go xs
@@ -498,7 +498,6 @@ stripQuotes which (x:xs) = go xs
                         go ('\\':'\\':xs) = '\\':go xs
                         go ('\\':which:xs) = which:go xs
                         go (x:xs) = x:go xs
-                     
-fApp2pApp (T (Identity (FunApp x args))) = (F (Identity (PredApp x args))) 
-}
 
+fApp2pApp (T (Identity (FunApp x args))) = (F (Identity (PredApp x args)))
+}

--- a/ParserC.y
+++ b/ParserC.y
@@ -1,6 +1,6 @@
 {
 module ParserC where
-    
+
 import Data.Char
 import Data.Data
 import Data.Ratio
@@ -17,8 +17,8 @@ import Control.Monad.State
 
 %name parseTPTPwithComment
 %tokentype { Token }
-%error { 
-          
+%error {
+
           ((\xs -> case xs of
                     xs -> error ("Parse error, pos: "++show (take 25 xs))))
        }
@@ -68,32 +68,32 @@ import Control.Monad.State
 
  comment            { CommentToken $$ }
 
-     
-%% 
+
+%%
 
 TPTP_file  :: {[TPTP_Input_ c]}
 TPTP_file  : {[]} | TPTP_input TPTP_file  {$1 : $2}
-           
+
 TPTP_input  :: {TPTP_Input_ c}
-TPTP_input  : annotated_formula  {$1} 
+TPTP_input  : annotated_formula  {$1}
              | include  { $1 }
              | comment { Comment $1 }
 
 annotated_formula  :: {TPTP_Input_ c}
-annotated_formula  :  fof_annotated  {$1} 
+annotated_formula  :  fof_annotated  {$1}
                     | cnf_annotated  {$1}
 
 fof_annotated  :: {TPTP_Input_ c}
 fof_annotated  : fof lp name  comma formula_role  comma fof_formula  annotations  rp dot
        { AFormula        $3               $5                $7           $8 }
-                
+
 cnf_annotated  :: {TPTP_Input}
 cnf_annotated  : cnf lp name  comma formula_role  comma cnf_formula  annotations  rp dot
        { AFormula          $3              $5  (univquant_free_vars $7) $8 }
-       
-       
+
+
 annotations  :: { Annotations }
-annotations  :  comma source optional_info  { Annotations $2 $3 } 
+annotations  :  comma source optional_info  { Annotations $2 $3 }
     | { NoAnnotations }
 
 formula_role  :: {Role}
@@ -103,44 +103,44 @@ formula_role  : lower_word_ { Role $1 }
 fof_formula  :: {F c}
 fof_formula  : binary_formula  { $1 }
               | unitary_formula  { $1 }
-      
+
 binary_formula  :: {F c}
 binary_formula  : nonassoc_binary  {$1}
                  | assoc_binary  {$1}
-                 
+
 nonassoc_binary  :: {F c}
-nonassoc_binary  : unitary_formula  binary_connective  unitary_formula 
+nonassoc_binary  : unitary_formula  binary_connective  unitary_formula
                   { $2 $1 $3 }
 
-                  
+
 assoc_binary  :: {F c}
 assoc_binary  : or_formula  { $1 }
                | and_formula  { $1 }
-    
-                 
+
+
 or_formula  :: {F c}
 or_formula  : unitary_formula   vline  unitary_formula  more_or_formula
                { L.foldl (.|.) ($1 .|. $3) $4 }
-             
+
 more_or_formula  :: {[F c]}
-more_or_formula  : {[]} | vline  unitary_formula more_or_formula 
+more_or_formula  : {[]} | vline  unitary_formula more_or_formula
                   { $2 : $3 }
-                  
+
 and_formula  :: {F c}
 and_formula  : unitary_formula  ampersand unitary_formula  more_and_formula
                { L.foldl (.&.) ($1 .&. $3) $4 }
 
 
 more_and_formula  :: {[F c]}
-more_and_formula  : {[]} | ampersand unitary_formula more_and_formula 
+more_and_formula  : {[]} | ampersand unitary_formula more_and_formula
                    { $2 : $3 }
-                   
+
 unitary_formula  :: {FormulaC}
 unitary_formula  :  quantified_formula  {$1}
                   | unary_formula       {$1}
                   | atomic_formula      {$1}
                   | lp fof_formula  rp  {$2}
-                   
+
 quantified_formula  :: {F c}
 quantified_formula  : quantifier  lbra variable_list  rbra colon unitary_formula
                      { $1 $3 $6 `withComments` comm $5 }
@@ -152,7 +152,7 @@ variable_list  : variable  { [$1] }
 unary_formula  :: {F c}
 unary_formula  : unary_connective  unitary_formula  { $1 $2 }
                 | fol_infix_unary  { $1 }
-   
+
 
 
 
@@ -164,20 +164,20 @@ cnf_formula  :: {F c}
 cnf_formula  :  lp disjunction  rp  { $2 }
               | disjunction  { $1 }
 
-                
+
 disjunction  :: {F c}
-disjunction  : literal  more_disjunction 
+disjunction  : literal  more_disjunction
               { L.foldl (.|.) $1 $2 }
-              
+
 more_disjunction  :: {[F c]}
-more_disjunction  :  {[]} | vline  literal more_disjunction 
+more_disjunction  :  {[]} | vline  literal more_disjunction
                    { $2 : $3 }
 
 literal  :: {FormulaC}
-literal  : atomic_formula  {$1} 
-          | tilde atomic_formula  { (.~.) $2} 
+literal  : atomic_formula  {$1}
+          | tilde atomic_formula  { (.~.) $2}
           | fol_infix_unary  {$1}
-          
+
 fol_infix_unary  :: {F c}
 fol_infix_unary  : term  infix_inequality  term  { $2 $1 $3 }
 
@@ -192,93 +192,93 @@ binary_connective  : iff { (.<=>.) }
                     | nor  { (.~|.) }
                     | nand { (.~&.) }
 
---- assoc_connective  : vline  
+--- assoc_connective  : vline
 ---                    | ampersand
-                   
+
 unary_connective  :: {FormulaC -> FormulaC}
 unary_connective  : tilde { (.~.) }
 
--- defined_type  :== atomic_defined_word 
+-- defined_type  :== atomic_defined_word
 
 -- defined_type  :== $oType | $o | $iType | $i | $tType | $real | $int
--- system_type  :== atomic_system_word 
+-- system_type  :== atomic_system_word
 
-atomic_formula  :: {F c} 
+atomic_formula  :: {F c}
 atomic_formula  :  plain_atomic_formula    {$1}
                  | defined_atomic_formula  {$1}
                  | system_atomic_formula   {$1}
-                 
+
 
 plain_atomic_formula  :: {F c}
 plain_atomic_formula  : plain_term  { fApp2pApp $1 }
 
--- plain_atomic_formula  :== proposition  | predicate  lp arguments  rp 
--- proposition  :== predicate 
--- predicate  :== atomic_word 
+-- plain_atomic_formula  :== proposition  | predicate  lp arguments  rp
+-- proposition  :== predicate
+-- predicate  :== atomic_word
 
 defined_atomic_formula  :: {F c}
-defined_atomic_formula  :  defined_plain_formula  {$1} 
+defined_atomic_formula  :  defined_plain_formula  {$1}
                          | defined_infix_formula  {$1}
-                         
+
 defined_plain_formula  :: {F c}
 defined_plain_formula  : defined_plain_term  {fApp2pApp $1}
-                        
---defined_plain_formula  :== defined_prop  | defined_pred  lp arguments  rp 
---defined_prop  :== atomic_defined_word 
+
+--defined_plain_formula  :== defined_prop  | defined_pred  lp arguments  rp
+--defined_prop  :== atomic_defined_word
 --defined_prop  :== $true | $false
---defined_pred  :== atomic_defined_word 
+--defined_pred  :== atomic_defined_word
 --defined_pred  :== $equal
 
 
 defined_infix_formula  :: {F c}
 defined_infix_formula  : term  defined_infix_pred  term  { $2 $1 $3 }
-                        
-defined_infix_pred :: { T c -> T c -> F c } 
+
+defined_infix_pred :: { T c -> T c -> F c }
 defined_infix_pred  : infix_equality  { $1 }
 
 infix_equality  :: { TermC -> TermC -> FormulaC }
 infix_equality  : equals { (.=.) }
-                
+
 infix_inequality  :: { TermC -> TermC -> FormulaC }
 infix_inequality  : nequals { (.!=.) }
 
-system_atomic_formula  :: {F c} 
+system_atomic_formula  :: {F c}
 system_atomic_formula  : system_term  {fApp2pApp $1}
 
-term  :: {TermC}                        
+term  :: {TermC}
 term  :  function_term  {$1}
        | variable       {var $1}
-       
+
 function_term  :: {TermC}
-function_term  : plain_term {$1} 
+function_term  : plain_term {$1}
                 | defined_term  {$1}
                 | system_term {$1}
 
-plain_term  :: {TermC}                        
+plain_term  :: {TermC}
 plain_term  :  constant                  {fApp $1 []}
              | functor  lp arguments  rp {fApp $1 $3}
-              
+
 constant  :: {AtomicWord}
 constant  : functor {$1}
 
 functor  :: {AtomicWord}
 functor  : atomic_word {$1}
 
-defined_term  :: {TermC}                        
-defined_term  : defined_atom {$1} 
+defined_term  :: {TermC}
+defined_term  : defined_atom {$1}
                | defined_atomic_term {$1}
-               
 
-defined_atom  :: {TermC}                        
-defined_atom  : number {numberLitTerm $1} 
+
+defined_atom  :: {TermC}
+defined_atom  : number {numberLitTerm $1}
                | distinct_object {distinctObjectTerm (stripQuotes '"' $1)}
-                 
-defined_atomic_term :: {T c}                
+
+defined_atomic_term :: {T c}
 defined_atomic_term  : defined_plain_term {$1}
-                      
-defined_plain_term  :: {TermC}                        
-defined_plain_term  : defined_constant {fApp (AtomicWord $1) []} 
-                     | defined_functor  lp arguments  rp {fApp (AtomicWord $1) $3} 
+
+defined_plain_term  :: {TermC}
+defined_plain_term  : defined_constant {fApp (AtomicWord $1) []}
+                     | defined_functor  lp arguments  rp {fApp (AtomicWord $1) $3}
 
 defined_constant  :: {String}
 defined_constant  : defined_functor {$1}
@@ -288,16 +288,16 @@ defined_functor  :: {String}
 defined_functor  : atomic_defined_word {$1}
 -- defined_functor  :==
 
-system_term  :: {TermC} 
+system_term  :: {TermC}
 system_term  :  system_constant  {fApp (AtomicWord $1) []}
-              | system_functor  lp arguments  rp {fApp (AtomicWord $1) $3} 
+              | system_functor  lp arguments  rp {fApp (AtomicWord $1) $3}
 
-system_constant  :: {String}                
+system_constant  :: {String}
 system_constant  : system_functor  {$1}
 
-system_functor  :: {String}                
+system_functor  :: {String}
 system_functor  : atomic_system_word {$1}
-                 
+
 variable  :: {V}
 variable  : upper_word {V $1}
 
@@ -305,111 +305,111 @@ arguments  :: {[T c]}
 arguments  : term  {[$1]}
             | term  comma arguments  { $1 : $3 }
 
-source  :: {GTerm} 
+source  :: {GTerm}
 source  : general_term  {$1}
 
 -- source  :== dag_source  | internal_source  | external_source  | unknown
 
--- dag_source  :== name  | inference_record 
+-- dag_source  :== name  | inference_record
 
--- inference_record  :== inference lp inference_rule  comma useful_info  comma  [parent_list ] rp 
--- inference_rule  :== atomic_word 
--- parent_list  :== parent_info  | parent_info  comma parent_list 
--- parent_info  :== source parent_details 
--- parent_details  :== :general_list  | null 
--- internal_source  :== introduced lp intro_type optional_info  rp 
+-- inference_record  :== inference lp inference_rule  comma useful_info  comma  [parent_list ] rp
+-- inference_rule  :== atomic_word
+-- parent_list  :== parent_info  | parent_info  comma parent_list
+-- parent_info  :== source parent_details
+-- parent_details  :== :general_list  | null
+-- internal_source  :== introduced lp intro_type optional_info  rp
 -- intro_type  :== definition | axiom_of_choice | tautology | assumption
--- external_source  :== file_source  | theory  | creator_source 
--- file_source  :== file lp file_name file_info  rp 
--- file_info  :==  comma name  | null 
--- theory  :== theory lp theory_name optional_info  rp 
+-- external_source  :== file_source  | theory  | creator_source
+-- file_source  :== file lp file_name file_info  rp
+-- file_info  :==  comma name  | null
+-- theory  :== theory lp theory_name optional_info  rp
 -- theory_name  :== equality | ac
--- creator_source  :== creator lp creator_name optional_info  rp 
--- creator_name  :== atomic_word 
+-- creator_source  :== creator lp creator_name optional_info  rp
+-- creator_name  :== atomic_word
 
-optional_info  :: {UsefulInfo} 
+optional_info  :: {UsefulInfo}
 optional_info  :  comma useful_info  {$2} |  {NoUsefulInfo}
-    
+
 useful_info  :: { UsefulInfo }
 useful_info  : general_list  {UsefulInfo $1}
 
 -- useful_info  :== [] | [info_items ]
--- info_items  :== info_item  | info_item  comma info_items 
--- info_item  :== formula_item  | inference_item  | general_function 
--- formula_item  :== description_item  | iquote_item 
--- description_item  :== description lp atomic_word  rp 
--- iquote_item  :== iquote lp atomic_word  rp 
--- inference_item  :== inference_status  | assumptions_record  | refutation 
--- inference_status  :== status lp status_value  rp  | inference_info 
+-- info_items  :== info_item  | info_item  comma info_items
+-- info_item  :== formula_item  | inference_item  | general_function
+-- formula_item  :== description_item  | iquote_item
+-- description_item  :== description lp atomic_word  rp
+-- iquote_item  :== iquote lp atomic_word  rp
+-- inference_item  :== inference_status  | assumptions_record  | refutation
+-- inference_status  :== status lp status_value  rp  | inference_info
 -- status_value  :== suc | unp | sap | esa | sat | fsa | thm | eqv | tac | wec | eth | tau | wtc | wth | cax | sca | tca | wca |cup | csp | ecs | csa | cth | ceq | unc | wcc | ect | fun | uns | wuc | wct | scc | uca | noc
 
--- inference_info  :== inference_rule  lp atomic_word  comma general_list  rp 
--- assumptions_record  :== assumptions lp [name_list ] rp 
--- refutation  :== refutation lp file_source  rp 
+-- inference_info  :== inference_rule  lp atomic_word  comma general_list  rp
+-- assumptions_record  :== assumptions lp [name_list ] rp
+-- refutation  :== refutation lp file_source  rp
 
 include :: {TPTP_Input_ c}
-include  : include_ lp file_name formula_selection  rp dot { Include $3 $4 } 
+include  : include_ lp file_name formula_selection  rp dot { Include $3 $4 }
 
 formula_selection  :: {[AtomicWord]}
-formula_selection  :  comma lbra name_list  rbra { $3 } 
+formula_selection  :  comma lbra name_list  rbra { $3 }
                     |   { [] }
 
 name_list  :: {[AtomicWord]}
 name_list  : name  {[$1]}
             | name  comma name_list  { $1 : $3 }
 
-              
+
 general_term  :: {GTerm}
-general_term  :  general_data  {GTerm $1} 
-               | general_data colon general_term  {ColonSep $1 $3} 
-               | general_list {GList $1} 
+general_term  :  general_data  {GTerm $1}
+               | general_data colon general_term  {ColonSep $1 $3}
+               | general_list {GList $1}
 
 general_data  :: {GData}
-general_data  :  atomic_word  { GWord $1 } 
-               | atomic_word  lp general_terms  rp { GApp $1 $3 }  
+general_data  :  atomic_word  { GWord $1 }
+               | atomic_word  lp general_terms  rp { GApp $1 $3 }
                | variable  { GVar $1 }
                | number  { GNumber $1 }
                | distinct_object { GDistinctObject (stripQuotes '"' $1) }
                | formula_data  { $1 }
-               
+
 formula_data :: {GData}
 formula_data  : dollar_word lp fof_formula  rp { GFormulaData $1 $3 }
               -- too ambiguous | dollar_word lp cnf_formula  rp { GFormulaData $1 $3 }
-                
+
 general_list  :: {[GTerm]}
 general_list  : lbra rbra {[]}
                | lbra general_terms  rbra {$2}
-               
+
 general_terms  :: {[GTerm]}
-general_terms  :  general_term  {[$1]} 
+general_terms  :  general_term  {[$1]}
                 | general_term  comma general_terms  {$1 : $3}
 
 name  :: {AtomicWord}
 name  : atomic_word  {$1}
        | unsigned_integer {AtomicWord(show $1)}
-         
-atomic_word  :: {AtomicWord}       
+
+atomic_word  :: {AtomicWord}
 atomic_word  : lower_word_ {AtomicWord $1}
               | single_quoted{AtomicWord (stripQuotes '\'' $1)}
-                
-atomic_defined_word  :: {String}              
+
+atomic_defined_word  :: {String}
 atomic_defined_word  : dollar_word{$1}
-                      
-atomic_system_word  :: {String}              
+
+atomic_system_word  :: {String}
 atomic_system_word  : dollar_dollar_word{$1}
 
 number  :: {Rational} -- maybe keep track of the number type that was actually parsed
-number  : integer {fromIntegral $1} | rational {$1} | real {$1}  
+number  : integer {fromIntegral $1} | rational {$1} | real {$1}
 
 integer :: {Integer}
 integer : signed_integer {$1} | unsigned_integer {$1}
 
-rational :: {Rational} 
-rational : integer tok_slash unsigned_integer {$1 % $3} 
-    
-file_name  :: {String}              
+rational :: {Rational}
+rational : integer tok_slash unsigned_integer {$1 % $3}
+
+file_name  :: {String}
 file_name  : single_quoted {stripQuotes '\'' $1}
-            
+
 lower_word_ :: {String}
 lower_word_ : lower_word {$1} | fof {"fof"} | cnf {"cnf"} | include_ {"include"} -- "fof" is a perfectly cromulent lower_word, but it is interpreted as a "fof" token
 
@@ -490,7 +490,7 @@ real               : tok_real                comment_list { $1 }
 
 comment_list :: {[String]}
 comment_list : {[]} | comment comment_list { $1 : $2 }
-       
+
 {
 data AToken = AToken { tok :: Token, comm :: [String] }
 
@@ -514,4 +514,3 @@ stripQuotes which (x:xs) = go xs
 fApp2pApp (T mf) = F $ do FunApp x args <- mf
                           return $ PredApp x args
 }
-

--- a/Util.hs
+++ b/Util.hs
@@ -26,6 +26,6 @@ getTyRep1 _ = mkTyConApp (typeRepTyCon (typeOf1 (undefined :: c ()))) []
 mkTypeOfForRank2Kind :: forall x c. Typeable1 c => String -> String -> x c -> TypeRep
 mkTypeOfForRank2Kind moduleName typeName = const tr
     where
-        tc = mkTyCon3 packageName moduleName typeName  
+        tc = mkTyCon3 packageName moduleName typeName
         tr = mkTyConApp tc [getTyRep1 (undefined :: c ())]
 #endif

--- a/logic-TPTP.cabal
+++ b/logic-TPTP.cabal
@@ -1,4 +1,4 @@
-name: logic-TPTP    
+name: logic-TPTP
 version: 0.4.2.0
 cabal-version: >= 1.6
 build-type: Simple
@@ -7,7 +7,7 @@ license-file: LICENSE
 maintainer: Ahn, Ki Yung <kya@pdx.edu>, Daniel Schüssler <daniels@community.haskell.org>
 bug-reports: http://github.com/DanielSchuessler/logic-TPTP/issues
 synopsis: Import, export etc. for TPTP, a syntax for first-order logic
-description: 
+description:
  For information about the TPTP format, see <http://www.cs.miami.edu/~tptp/>.
  .
  Components:
@@ -19,19 +19,19 @@ description:
  - Pretty-printer ('pretty')
  .
  - QuickCheck instances (generation of random formulae)
- .  
+ .
  - 'diff' : Get a \"formula\" which represents the differences between two given formulae (equal subexpressions are truncated; so are the subexpressions of subexpressions whose heads already differ)
  .
  Tests passed:
  .
  - For randomly generated formulae, @parse . toTPTP == id@
  .
- - For all files in the TPTP (v 5.2.0) distribution's @Problems@ subtree which don't match the regex \"^(thf|tff)\(\", @parse . toTPTP . parse == parse@ 
+ - For all files in the TPTP (v 5.2.0) distribution's @Problems@ subtree which don't match the regex \"^(thf|tff)\(\", @parse . toTPTP . parse == parse@
  .
  Not yet implemented: The new /thf/ and /tff/ formula types.
  .
- 
- 
+
+
 category: Codec,Math,Theorem Provers
 author: Daniel Schüssler
 cabal-version: >= 1.6
@@ -49,12 +49,12 @@ tested-with: GHC==7.0.4
 source-repository head
  type: git
  location: http://github.com/DanielSchuessler/logic-TPTP.git
- 
- 
+
+
 
 Library
  ghc-options: -Wall -O2
- 
+
  build-depends:      base >=4 && < 5
                    , array
                    , syb
@@ -65,20 +65,19 @@ Library
                    , pointed
                    , transformers
                    , transformers-compat >= 0.3
- 
+
  exposed-modules:   Codec.TPTP.Import
                   , Codec.TPTP.Base
                   , Codec.TPTP
                   , Codec.TPTP.Pretty
                   , Codec.TPTP.Export
                   , Codec.TPTP.Diff
- 
+
  other-modules:
-                    Lexer     
+                    Lexer
                   , Parser
                   , ParserC
                   , Codec.TPTP.QuickCheck
                   , Util
 
  build-tools: alex, happy
-

--- a/testing/Common.hs
+++ b/testing/Common.hs
@@ -13,29 +13,29 @@ import Codec.TPTP
 
 
 data AFormulaComparison = OtherSame | OtherDiff String String | FormulaDiff (F DiffResult)
-                        
+
 instance Monoid AFormulaComparison where
     mempty = OtherSame
-             
+
     -- keep the most interesting comparison result
     mappend OtherSame y = y
     mappend x OtherSame = x
     mappend x@(OtherDiff _ _) y@(FormulaDiff (F y0)) = if isSame y0 then y else x
-    mappend x@(FormulaDiff (F x0)) y@(OtherDiff _ _) = if isSame x0 then x else y 
+    mappend x@(FormulaDiff (F x0)) y@(OtherDiff _ _) = if isSame x0 then x else y
     mappend x@(OtherDiff _ _) (OtherDiff _ _) = x
     mappend x@(FormulaDiff _ ) (FormulaDiff _ ) = x
-                                                                
+
 instance Pretty AFormulaComparison where
     pretty (OtherSame) = dullgreen.text$"OtherSame"
-    pretty (OtherDiff x y) = sep 
+    pretty (OtherDiff x y) = sep
                              [dullred.text$"OtherDiff"
                              ,pretty x
                              ,pretty y
                              ]
     pretty (FormulaDiff fd) = pretty fd
-     
+
 compareOther ::  (Eq a, Show a) => a -> a -> AFormulaComparison
-compareOther x y = if x==y then OtherSame else OtherDiff (show x) (show y) 
+compareOther x y = if x==y then OtherSame else OtherDiff (show x) (show y)
 
 diffAFormula :: (Eq (t (Formula0 (T t) (F t))),Show (t (Formula0 (T t) (F t))),Diffable (F t) (F DiffResult)) =>TPTP_Input_ t -> TPTP_Input_ t -> AFormulaComparison
 diffAFormula (AFormula a b c d) (AFormula a1 b1 c1 d1) =
@@ -44,9 +44,9 @@ diffAFormula (AFormula a b c d) (AFormula a1 b1 c1 d1) =
             , FormulaDiff (diff c c1)
             , compareOther d d1
             ]
-diffAFormula x y = compareOther x y 
-                  
+diffAFormula x y = compareOther x y
+
 findUnsupportedFormulaType ::  String -> Maybe String
-findUnsupportedFormulaType = 
-    let re = compile "^(thf|tff)\\(" [multiline] 
+findUnsupportedFormulaType =
+    let re = compile "^(thf|tff)\\(" [multiline]
     in (\x -> (!!1) `fmap` match re x [])

--- a/testing/ParseRandom.hs
+++ b/testing/ParseRandom.hs
@@ -1,10 +1,10 @@
-{-# OPTIONS 
- -fglasgow-exts 
- -XCPP 
- -XTemplateHaskell 
- -XNamedFieldPuns 
- -XRecordWildCards 
- -XDeriveDataTypeable 
+{-# OPTIONS
+ -fglasgow-exts
+ -XCPP
+ -XTemplateHaskell
+ -XNamedFieldPuns
+ -XRecordWildCards
+ -XDeriveDataTypeable
  -XOverlappingInstances
  -XPackageImports
  -fwarn-incomplete-patterns
@@ -34,12 +34,12 @@ import Text.PrettyPrint.ANSI.Leijen
 import System.Exit
 import Text.Regex.PCRE.Light.Char8
 import Common
-    
+
 import "logic-TPTP" Codec.TPTP
 
 infilename = getArgs
 parseRes = return . parse =<< readFile =<< infilename
-         
+
 --main = forever $ quickCheck prop_test_ie --iei_i
 
 --main = stressTestParser

--- a/testing/PrettyPrintFile.hs
+++ b/testing/PrettyPrintFile.hs
@@ -1,10 +1,10 @@
-{-# OPTIONS 
- -fglasgow-exts 
- -XCPP 
- -XTemplateHaskell 
- -XNamedFieldPuns 
- -XRecordWildCards 
- -XDeriveDataTypeable 
+{-# OPTIONS
+ -fglasgow-exts
+ -XCPP
+ -XTemplateHaskell
+ -XNamedFieldPuns
+ -XRecordWildCards
+ -XDeriveDataTypeable
  -XOverlappingInstances
  -XPackageImports
  -fwarn-incomplete-patterns
@@ -34,9 +34,8 @@ import Data.Monoid
 import Text.PrettyPrint.ANSI.Leijen
 import System.Exit
 import Text.Regex.PCRE.Light.Char8
-    
+
 import "logic-TPTP" Codec.TPTP
 
 
 main = putStrLn . prettySimple . parse =<< readFile =<< getArgs
-

--- a/testing/Prof.hs
+++ b/testing/Prof.hs
@@ -1,10 +1,10 @@
-{-# OPTIONS 
- -fglasgow-exts 
- -XCPP 
- -XTemplateHaskell 
- -XNamedFieldPuns 
- -XRecordWildCards 
- -XDeriveDataTypeable 
+{-# OPTIONS
+ -fglasgow-exts
+ -XCPP
+ -XTemplateHaskell
+ -XNamedFieldPuns
+ -XRecordWildCards
+ -XDeriveDataTypeable
  -XOverlappingInstances
  -XPackageImports
  -fwarn-incomplete-patterns
@@ -20,9 +20,9 @@ import Test.QuickCheck.Gen(Gen(unGen))
 import System.SimpleArgs(Args(..))
 import System.Random(newStdGen)
 
-   
+
 size = 100
-    
+
 randomF :: IO TPTP_Input
 randomF = (\seed -> unGen arbitrary seed size) `fmap` newStdGen
 

--- a/testing/TestImportExportImportFile.hs
+++ b/testing/TestImportExportImportFile.hs
@@ -12,7 +12,7 @@ import Data.Monoid
 import Text.PrettyPrint.ANSI.Leijen
 import System.Exit
 import Common
-    
+
 import "logic-TPTP" Codec.TPTP
 
 
@@ -25,13 +25,13 @@ main = do
   print_export <- getArgs
   forM_ files (diff_once_twice print_export)
   exitWith ExitSuccess
-         
+
 diff_once_twice ::  Bool -> String -> IO ()
 diff_once_twice print_export infilename'  = do
   --let tmp = "/tmp/tmp.tptp"
   putStrLn infilename'
   input <- readFile infilename'
-  case findUnsupportedFormulaType input of 
+  case findUnsupportedFormulaType input of
      Just x -> putStrLn . prettySimple . yellow . text $ ("Skipping unsupported formula type "++x)
      Nothing -> do
 
@@ -42,8 +42,8 @@ diff_once_twice print_export infilename'  = do
       let dif = mconcat (zipWith diffAFormula once twice)
       let success = (putStrLn . prettySimple . dullgreen . text $ "Ok")
 
-      -- case dif of 
-      --   OtherSame -> success 
+      -- case dif of
+      --   OtherSame -> success
       --   FormulaDiff (F Same) -> success
       --   _ -> do
       --     putStrLn . prettySimple $ dif
@@ -54,4 +54,3 @@ diff_once_twice print_export infilename'  = do
          else do
            putStrLn . prettySimple $ dif
            exitWith (ExitFailure 1)
-

--- a/testing/TestImportExportRandom.hs
+++ b/testing/TestImportExportRandom.hs
@@ -7,7 +7,7 @@ import System.IO
 import Test.QuickCheck
 import Common
 import Data.Functor.Identity
-    
+
 import "logic-TPTP" Codec.TPTP
 
 main ::  IO ()
@@ -19,18 +19,18 @@ prop_test_ie f =
 
       (let
           [g] = parse tptp -- $ trace tptp tptp
-    
+
           dif = diffAFormula f g
        in
           whenFail
-          (putStrLn . prettySimple $ dif) 
-          
+          (putStrLn . prettySimple $ dif)
+
            (f==g)
-          
-          -- (case dif of 
+
+          -- (case dif of
           --    OtherSame -> True
           --    FormulaDiff (F Same) -> True
           --    _ -> False
           -- ))
-                
+
       )

--- a/testing/compileTests.sh
+++ b/testing/compileTests.sh
@@ -6,8 +6,8 @@ mkdir -p bin
 mkdir -p obj
 
 for x in TestImportExportImportFile TestImportExportRandom PrettyPrintFile ParseRandom; do
-    
+
 #    ghc -prof -auto-all -outputdir obj -o bin/$x --make -O2 -main-is $x $x
     ghc -outputdir obj -o bin/$x --make -O2 -main-is $x $x
-    
+
 done

--- a/testing/profiling.sh
+++ b/testing/profiling.sh
@@ -7,8 +7,7 @@ mkdir -p obj
 
 x=Prof
 ghc -fforce-recomp -prof -auto-all -outputdir obj -o bin/$x --make -O2 -main-is $x $x
-    
+
 echo "Running..."
 bin/$x +RTS -P -RTS 1000
 x-www-browser "$x.prof"
-


### PR DESCRIPTION
The fixes are pretty simple
- `Data a => Data (Identity a)` is now in `Data.Data` so the instance definition in  `Codec.TPTP.Base` 
  is no longer needed
- `(<$>)` is now on `Prelude` so I just hid it.

I test this with `ghc-7.8.3` and `ghc-7.10.1`
