### PR TITLE
fix compilation error with transformers >=0.5.1 and GHC <7.10

### DIFF
--- a/Codec/TPTP/Base.hs
+++ b/Codec/TPTP/Base.hs
@@ -37,14 +37,16 @@ import Data.Functor.Classes() -- Import Eq,Ord,Show,Read orphan instances for Da
 import Util
 #endif
 
-#if !MIN_VERSION_base(4,8,0)
+#if !MIN_VERSION_base(4,8,0) && !MIN_VERSION_transformers(0,5,1)
 deriving instance Data a => Data (Identity a)
 #endif
 
+#if !MIN_VERSION_base(4,8,0) && !MIN_VERSION_transformers(0,5,1)
 #if MIN_VERSION_base(4,7,0)
 deriving instance Typeable Identity
 #else
 deriving instance Typeable1 Identity
+#endif
 #endif
 
 -- * Basic undecorated formulae and terms


### PR DESCRIPTION
The error is caused by overlapping instances of Typeable/Data instances for Identity functor.

transformers-0.5.1 defines own ones on GHC <7.10 and the definitions clashes with the ones in Codec.TPTP.Base.
