### PR TITLE
Consolidate orphan Data, Typeable instances for Identity with transformers-compat

### DIFF
--- a/Codec/TPTP/Base.hs
+++ b/Codec/TPTP/Base.hs
@@ -4,7 +4,6 @@
   , UndecidableInstances, DeriveDataTypeable, GeneralizedNewtypeDeriving
   , OverlappingInstances, ScopedTypeVariables
   #-}
-{-# OPTIONS -Wall -fno-warn-orphans #-}
 
 module Codec.TPTP.Base where
 
@@ -30,23 +29,11 @@ import Test.QuickCheck hiding ((.&.))
 import Data.Pointed
 import Data.Copointed
 #if !MIN_VERSION_transformers(0,4,0)
-import Data.Functor.Classes() -- Import Eq,Ord,Show,Read orphan instances for Data.Functor.Identity from transformers-compat package
+import Control.Monad.Trans.Instances () -- Import Eq,Ord,Show,Read,Data,Typeable orphan instances for Data.Functor.Identity from transformers-compat package
 #endif
 
 #if !MIN_VERSION_base(4,7,0)
 import Util
-#endif
-
-#if !MIN_VERSION_base(4,8,0) && !MIN_VERSION_transformers(0,5,1)
-deriving instance Data a => Data (Identity a)
-#endif
-
-#if !MIN_VERSION_base(4,8,0) && !MIN_VERSION_transformers(0,5,1)
-#if MIN_VERSION_base(4,7,0)
-deriving instance Typeable Identity
-#else
-deriving instance Typeable1 Identity
-#endif
 #endif
 
 -- * Basic undecorated formulae and terms

--- a/logic-TPTP.cabal
+++ b/logic-TPTP.cabal
@@ -64,7 +64,7 @@ Library
                    , mtl
                    , pointed
                    , transformers
-                   , transformers-compat >= 0.3
+                   , transformers-compat >= 0.5
 
  exposed-modules:   Codec.TPTP.Import
                   , Codec.TPTP.Base


### PR DESCRIPTION
`transformers-compat-0.5` [now exports](https://github.com/ekmett/transformers-compat/blob/2474b81c5797906f5057e741000c73147036d3ba/src/Control/Monad/Trans/Instances.hs#L276) orphan `Data` and `Typeable` instances for `Identity` from the `Control.Monad.Trans.Instances` module (which also reexports the `Eq`/`Ord`/`Read`/`Show` orphan instances for `Identity` from `Data.Functor.Classes`). To prevent potential instance conflicts, this pull request consolidates the orphans defined in `Codec.TPTP.Base` with the ones from `Control.Monad.Trans.Instances`.
