### PR TITLE
fix compilation error with containers >=0.5.8

### DIFF
--- a/Parser.y
+++ b/Parser.y
@@ -7,7 +7,7 @@ import Data.Ratio
 import Control.Monad
 import Data.List as L
 import Lexer
-import Data.Set as S
+import qualified Data.Set as S
 import Codec.TPTP.Base
 import System.IO
 import System.IO.Unsafe

--- a/ParserC.y
+++ b/ParserC.y
@@ -7,7 +7,7 @@ import Data.Ratio
 import Control.Monad
 import Data.List as L
 import Lexer
-import Data.Set as S
+import qualified Data.Set as S
 import Codec.TPTP.Base
 import System.IO
 import System.IO.Unsafe


### PR DESCRIPTION
From `containers >=0.5.8`, `Data.Set` also exports `take` function and it causes ambiguity.
This PR fixes the problem.

```
.stack-work/dist/x86_64-osx/Cabal-2.0.0.2/build/Parser.hs:2251:62: error:
    Ambiguous occurrence ‘take’
    It could refer to either ‘L.take’,
                             imported from ‘Data.List’ at .stack-work/dist/x86_64-osx/Cabal-2.0.0.2/build/Parser.hs:9:1-21
                             (and originally defined in ‘GHC.List’)
                          or ‘S.take’,
                             imported from ‘Data.Set’ at .stack-work/dist/x86_64-osx/Cabal-2.0.0.2/build/Parser.hs:11:1-20
                             (and originally defined in ‘Data.Set.Internal’)
     |
2251 |                     xs -> error ("Parse error, pos: "++show (take 25 xs))))
     |                                                              ^^^^
```