### PR TITLE
add Semigroup instances for V and AtomicWord

### DIFF
--- a/Codec/TPTP/Base.hs
+++ b/Codec/TPTP/Base.hs
@@ -22,6 +22,7 @@ import Control.Monad.State
 import Data.Data
 import Data.Function
 import Data.Monoid hiding(All)
+import Data.Semigroup (Semigroup)
 import Data.Set as S hiding(fold)
 import Data.String
 import Prelude --hiding(concat,foldl,foldl1,foldr,foldr1)
@@ -531,7 +532,7 @@ instance Arbitrary GTerm
 --
 -- Tip: Use the @-XOverloadedStrings@ compiler flag if you don't want to have to type /AtomicWord/ to construct an 'AtomicWord'
 newtype AtomicWord = AtomicWord String
-    deriving (Eq,Ord,Show,Data,Typeable,Read,Monoid,IsString)
+    deriving (Eq,Ord,Show,Data,Typeable,Read,Semigroup,Monoid,IsString)
 
 instance Arbitrary AtomicWord where
     arbitrary = frequency [  (5, AtomicWord <$> arbLowerWord)
@@ -540,7 +541,7 @@ instance Arbitrary AtomicWord where
 
 -- | Variable names
 newtype V = V String
-    deriving (Eq,Ord,Show,Data,Typeable,Read,Monoid,IsString)
+    deriving (Eq,Ord,Show,Data,Typeable,Read,Semigroup,Monoid,IsString)
 
 instance Arbitrary V where
     arbitrary = V <$> arbVar

--- a/logic-TPTP.cabal
+++ b/logic-TPTP.cabal
@@ -63,6 +63,7 @@ Library
                    , QuickCheck >= 2
                    , mtl
                    , pointed
+                   , semigroups
                    , transformers
                    , transformers-compat >= 0.5
 


### PR DESCRIPTION
This is necessary for GHC 8.4 where `Semigroup` is a superclass of `Monoid`.