### PR TITLE
adapt for MonadFail proposal (MFP)

### DIFF
--- a/ParserC.y
+++ b/ParserC.y
@@ -511,6 +511,7 @@ stripQuotes which (x:xs) = go xs
                         go ('\\':which:xs) = which:go xs
                         go (x:xs) = x:go xs
 
-fApp2pApp (T mf) = F $ do FunApp x args <- mf
-                          return $ PredApp x args
+fApp2pApp (T mf) = F $ do x <- mf
+                          case x of
+                            FunApp x args -> return $ PredApp x args
 }


### PR DESCRIPTION
This fixes following compilation error on GHC-8.6.

```
[ 8 of 11] Compiling ParserC          ( .stack-work/dist/x86_64-osx/Cabal-2.4.0.1/build/ParserC.hs, .stack-work/dist/x86_64-osx/Cabal-2.4.0.1/build/ParserC.o )

/Users/sakai/logic-TPTP/.stack-work/dist/x86_64-osx/Cabal-2.4.0.1/build/ParserC.hs:1347:19: error:
    • No instance for (Control.Monad.Fail.MonadFail Identity)
        arising from a use of ‘fApp2pApp’
    • In the first argument of ‘happyIn32’, namely
        ‘(fApp2pApp happy_var_1)’
      In the expression: happyIn32 (fApp2pApp happy_var_1)
      In a case alternative:
          happy_var_1 -> happyIn32 (fApp2pApp happy_var_1)
     |
1347 |                  (fApp2pApp happy_var_1
     |                   ^^^^^^^^^^^^^^^^^^^^^

/Users/sakai/logic-TPTP/.stack-work/dist/x86_64-osx/Cabal-2.4.0.1/build/ParserC.hs:1368:19: error:
    • No instance for (Control.Monad.Fail.MonadFail Identity)
        arising from a use of ‘fApp2pApp’
    • In the first argument of ‘happyIn34’, namely
        ‘(fApp2pApp happy_var_1)’
      In the expression: happyIn34 (fApp2pApp happy_var_1)
      In a case alternative:
          happy_var_1 -> happyIn34 (fApp2pApp happy_var_1)
     |
1368 |                  (fApp2pApp happy_var_1
     |                   ^^^^^^^^^^^^^^^^^^^^^

/Users/sakai/logic-TPTP/.stack-work/dist/x86_64-osx/Cabal-2.4.0.1/build/ParserC.hs:1405:19: error:
    • No instance for (Control.Monad.Fail.MonadFail Identity)
        arising from a use of ‘fApp2pApp’
    • In the first argument of ‘happyIn39’, namely
        ‘(fApp2pApp happy_var_1)’
      In the expression: happyIn39 (fApp2pApp happy_var_1)
      In a case alternative:
          happy_var_1 -> happyIn39 (fApp2pApp happy_var_1)
     |
1405 |                  (fApp2pApp happy_var_1
     |                   ^^^^^^^^^^^^^^^^^^^^^
```

The pattern match `FunApp x args <- mf` in `fApp2pApp` is desugared to use `MonadFail` class. But users of `fApp2pApp` use `Identity` monad which is not an instance of `MonadFail` class.
