### PR TITLE
fix to work with happy >=1.19.10

### DIFF
--- a/Codec/TPTP/Base.hs
+++ b/Codec/TPTP/Base.hs
@@ -320,6 +320,13 @@ univquant_free_vars cnf =
       [] -> cnf
       vars -> for_all vars cnf
 
+-- | Universally quantify all free variables in the formula
+univquant_free_vars_FC :: FormulaC -> FormulaC
+univquant_free_vars_FC cnf =
+    case S.toList (freeVars (forgetFC cnf)) of
+      [] -> cnf
+      vars -> for_all vars cnf
+
 instance FreeVars Formula where
     freeVars = foldF
                freeVars

--- a/ParserC.y
+++ b/ParserC.y
@@ -71,25 +71,25 @@ import Control.Monad.State
 
 %%
 
-TPTP_file  :: {[TPTP_Input_ c]}
+TPTP_file  :: {[TPTP_Input_C]}
 TPTP_file  : {[]} | TPTP_input TPTP_file  {$1 : $2}
 
-TPTP_input  :: {TPTP_Input_ c}
+TPTP_input  :: {TPTP_Input_C}
 TPTP_input  : annotated_formula  {$1}
              | include  { $1 }
              | comment { Comment $1 }
 
-annotated_formula  :: {TPTP_Input_ c}
+annotated_formula  :: {TPTP_Input_C}
 annotated_formula  :  fof_annotated  {$1}
                     | cnf_annotated  {$1}
 
-fof_annotated  :: {TPTP_Input_ c}
+fof_annotated  :: {TPTP_Input_C}
 fof_annotated  : fof lp name  comma formula_role  comma fof_formula  annotations  rp dot
        { AFormula        $3               $5                $7           $8 }
 
-cnf_annotated  :: {TPTP_Input}
+cnf_annotated  :: {TPTP_Input_C}
 cnf_annotated  : cnf lp name  comma formula_role  comma cnf_formula  annotations  rp dot
-       { AFormula          $3              $5  (univquant_free_vars $7) $8 }
+       { AFormula          $3              $5  (univquant_free_vars_FC $7) $8 }
 
 
 annotations  :: { Annotations }
@@ -100,38 +100,38 @@ formula_role  :: {Role}
 formula_role  : lower_word_ { Role $1 }
 
 
-fof_formula  :: {F c}
+fof_formula  :: {FormulaC}
 fof_formula  : binary_formula  { $1 }
               | unitary_formula  { $1 }
 
-binary_formula  :: {F c}
+binary_formula  :: {FormulaC}
 binary_formula  : nonassoc_binary  {$1}
                  | assoc_binary  {$1}
 
-nonassoc_binary  :: {F c}
+nonassoc_binary  :: {FormulaC}
 nonassoc_binary  : unitary_formula  binary_connective  unitary_formula
                   { $2 $1 $3 }
 
 
-assoc_binary  :: {F c}
+assoc_binary  :: {FormulaC}
 assoc_binary  : or_formula  { $1 }
                | and_formula  { $1 }
 
 
-or_formula  :: {F c}
+or_formula  :: {FormulaC}
 or_formula  : unitary_formula   vline  unitary_formula  more_or_formula
                { L.foldl (.|.) ($1 .|. $3) $4 }
 
-more_or_formula  :: {[F c]}
+more_or_formula  :: {[FormulaC]}
 more_or_formula  : {[]} | vline  unitary_formula more_or_formula
                   { $2 : $3 }
 
-and_formula  :: {F c}
+and_formula  :: {FormulaC}
 and_formula  : unitary_formula  ampersand unitary_formula  more_and_formula
                { L.foldl (.&.) ($1 .&. $3) $4 }
 
 
-more_and_formula  :: {[F c]}
+more_and_formula  :: {[FormulaC]}
 more_and_formula  : {[]} | ampersand unitary_formula more_and_formula
                    { $2 : $3 }
 
@@ -141,7 +141,7 @@ unitary_formula  :  quantified_formula  {$1}
                   | atomic_formula      {$1}
                   | lp fof_formula  rp  {$2}
 
-quantified_formula  :: {F c}
+quantified_formula  :: {FormulaC}
 quantified_formula  : quantifier  lbra variable_list  rbra colon unitary_formula
                      { $1 $3 $6 `withComments` comm $5 }
 
@@ -149,7 +149,7 @@ variable_list  :: {[V]}
 variable_list  : variable  { [$1] }
                 | variable  comma variable_list  { $1 : $3 }
 
-unary_formula  :: {F c}
+unary_formula  :: {FormulaC}
 unary_formula  : unary_connective  unitary_formula  { $1 $2 }
                 | fol_infix_unary  { $1 }
 
@@ -160,16 +160,16 @@ unary_formula  : unary_connective  unitary_formula  { $1 $2 }
 -- cnf_formula : assoc_binary {$1}
 --             | lp assoc_binary rp {$2}
 
-cnf_formula  :: {F c}
+cnf_formula  :: {FormulaC}
 cnf_formula  :  lp disjunction  rp  { $2 }
               | disjunction  { $1 }
 
 
-disjunction  :: {F c}
+disjunction  :: {FormulaC}
 disjunction  : literal  more_disjunction
               { L.foldl (.|.) $1 $2 }
 
-more_disjunction  :: {[F c]}
+more_disjunction  :: {[FormulaC]}
 more_disjunction  :  {[]} | vline  literal more_disjunction
                    { $2 : $3 }
 
@@ -178,7 +178,7 @@ literal  : atomic_formula  {$1}
           | tilde atomic_formula  { (.~.) $2}
           | fol_infix_unary  {$1}
 
-fol_infix_unary  :: {F c}
+fol_infix_unary  :: {FormulaC}
 fol_infix_unary  : term  infix_inequality  term  { $2 $1 $3 }
 
 quantifier :: {[V] -> FormulaC -> FormulaC}
@@ -203,24 +203,24 @@ unary_connective  : tilde { (.~.) }
 -- defined_type  :== $oType | $o | $iType | $i | $tType | $real | $int
 -- system_type  :== atomic_system_word
 
-atomic_formula  :: {F c}
+atomic_formula  :: {FormulaC}
 atomic_formula  :  plain_atomic_formula    {$1}
                  | defined_atomic_formula  {$1}
                  | system_atomic_formula   {$1}
 
 
-plain_atomic_formula  :: {F c}
+plain_atomic_formula  :: {FormulaC}
 plain_atomic_formula  : plain_term  { fApp2pApp $1 }
 
 -- plain_atomic_formula  :== proposition  | predicate  lp arguments  rp
 -- proposition  :== predicate
 -- predicate  :== atomic_word
 
-defined_atomic_formula  :: {F c}
+defined_atomic_formula  :: {FormulaC}
 defined_atomic_formula  :  defined_plain_formula  {$1}
                          | defined_infix_formula  {$1}
 
-defined_plain_formula  :: {F c}
+defined_plain_formula  :: {FormulaC}
 defined_plain_formula  : defined_plain_term  {fApp2pApp $1}
 
 --defined_plain_formula  :== defined_prop  | defined_pred  lp arguments  rp
@@ -230,10 +230,10 @@ defined_plain_formula  : defined_plain_term  {fApp2pApp $1}
 --defined_pred  :== $equal
 
 
-defined_infix_formula  :: {F c}
+defined_infix_formula  :: {FormulaC}
 defined_infix_formula  : term  defined_infix_pred  term  { $2 $1 $3 }
 
-defined_infix_pred :: { T c -> T c -> F c }
+defined_infix_pred :: { TermC -> TermC -> FormulaC }
 defined_infix_pred  : infix_equality  { $1 }
 
 infix_equality  :: { TermC -> TermC -> FormulaC }
@@ -242,7 +242,7 @@ infix_equality  : equals { (.=.) }
 infix_inequality  :: { TermC -> TermC -> FormulaC }
 infix_inequality  : nequals { (.!=.) }
 
-system_atomic_formula  :: {F c}
+system_atomic_formula  :: {FormulaC}
 system_atomic_formula  : system_term  {fApp2pApp $1}
 
 term  :: {TermC}
@@ -273,7 +273,7 @@ defined_atom  :: {TermC}
 defined_atom  : number {numberLitTerm $1}
                | distinct_object {distinctObjectTerm (stripQuotes '"' $1)}
 
-defined_atomic_term :: {T c}
+defined_atomic_term :: {TermC}
 defined_atomic_term  : defined_plain_term {$1}
 
 defined_plain_term  :: {TermC}
@@ -301,7 +301,7 @@ system_functor  : atomic_system_word {$1}
 variable  :: {V}
 variable  : upper_word {V $1}
 
-arguments  :: {[T c]}
+arguments  :: {[TermC]}
 arguments  : term  {[$1]}
             | term  comma arguments  { $1 : $3 }
 
@@ -347,7 +347,7 @@ useful_info  : general_list  {UsefulInfo $1}
 -- assumptions_record  :== assumptions lp [name_list ] rp
 -- refutation  :== refutation lp file_source  rp
 
-include :: {TPTP_Input_ c}
+include :: {TPTP_Input_C}
 include  : include_ lp file_name formula_selection  rp dot { Include $3 $4 }
 
 formula_selection  :: {[AtomicWord]}
@@ -373,7 +373,7 @@ general_data  :  atomic_word  { GWord $1 }
                | formula_data  { $1 }
 
 formula_data :: {GData}
-formula_data  : dollar_word lp fof_formula  rp { GFormulaData $1 $3 }
+formula_data  : dollar_word lp fof_formula  rp { GFormulaData $1 (forgetFC $3) }
               -- too ambiguous | dollar_word lp cnf_formula  rp { GFormulaData $1 $3 }
 
 general_list  :: {[GTerm]}


### PR DESCRIPTION
The `HappyWrap` newtypes introduced by https://github.com/simonmar/happy/pull/134 produces code like

```haskell
newtype HappyWrap4 = HappyWrap4 ([TPTP_Input_ c])
```

which results in "Not in scope: type variable" errors.

This commit avoid the problem by using concrete types instead of type variable, though I'm not sure if this is a desired fix.