### PR TITLE
switch TestImportExportRandom into a cabal test-suite

### DIFF
--- a/logic-TPTP.cabal
+++ b/logic-TPTP.cabal
@@ -104,7 +104,8 @@ Executable TestImportExportImportFile
  if !flag(BuildTestPrograms)
   buildable: False
 
-Executable TestImportExportRandom
+Test-suite TestImportExportRandom
+ type:              exitcode-stdio-1.0
  main-is:           TestImportExportRandom.hs
  other-modules:     Common
  hs-source-dirs:    testing
@@ -119,8 +120,6 @@ Executable TestImportExportRandom
  if impl(ghc <7.10)
   build-depends:    pcre-light <0.4.1
  other-extensions:  CPP
- if !flag(BuildTestPrograms)
-  buildable: False
 
 Executable PrettyPrintFile
  main-is:           PrettyPrintFile.hs


### PR DESCRIPTION
This PR is a continuation of #15 and makes `TestImportExportRandom` to be run on Travis-CI.