### PR TITLE
Run TestImportExportImportFile on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ script:
      curl -L -o TPTP-v7.3.0.tgz http://www.tptp.org/TPTP/Distribution/TPTP-v7.3.0.tgz && mv TPTP-v7.3.0.tgz $HOME/.tptp/
    fi
    tar zxf $HOME/.tptp/TPTP-v7.3.0.tgz
-   find -H TPTP-v7.3.0/Problems -type f -name "*.p" | cabal run TestImportExportImportFile -- False
+   find -H TPTP-v7.3.0/Problems -type f -name "*.p" -size -512k | cabal run TestImportExportImportFile -- False
 
  - cabal sdist   # tests that a source-distribution can be generated
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ script:
      curl -L -o TPTP-v7.3.0.tgz http://www.tptp.org/TPTP/Distribution/TPTP-v7.3.0.tgz && mv TPTP-v7.3.0.tgz $HOME/.tptp/
    fi
    tar zxf $HOME/.tptp/TPTP-v7.3.0.tgz
-   find -H TPTP-v7.3.0/Problems -type f -name "*.p" -size -512k | cabal run TestImportExportImportFile -- False
+   find -H TPTP-v7.3.0/Problems -type f -name "*.p" -size -512k | cabal run TestImportExportImportFile -- False --print-failure-only
 
  - cabal sdist   # tests that a source-distribution can be generated
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
   directories:
     - $HOME/.cabsnap
     - $HOME/.cabal/packages
+    - $HOME/.tptp
 
 before_cache:
   - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
@@ -83,6 +84,13 @@ script:
  - cabal build   # this builds all libraries and executables (including tests/benchmarks)
  - cabal test
 # - cabal check
+ - |
+   if [ ! -f $HOME/.tptp/TPTP-v7.3.0.tgz ]; then
+     curl -L -o TPTP-v7.3.0.tgz http://www.tptp.org/TPTP/Distribution/TPTP-v7.3.0.tgz && mv TPTP-v7.3.0.tgz $HOME/.tptp/
+   fi
+   tar zxf $HOME/.tptp/TPTP-v7.3.0.tgz
+   find -H TPTP-v7.3.0/Problems -type f | cabal run TestImportExportImportFile -- False
+
  - cabal sdist   # tests that a source-distribution can be generated
 
 # Check that the resulting source distribution can be built & installed.

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ script:
      curl -L -o TPTP-v7.3.0.tgz http://www.tptp.org/TPTP/Distribution/TPTP-v7.3.0.tgz && mv TPTP-v7.3.0.tgz $HOME/.tptp/
    fi
    tar zxf $HOME/.tptp/TPTP-v7.3.0.tgz
-   find -H TPTP-v7.3.0/Problems -type f | cabal run TestImportExportImportFile -- False
+   find -H TPTP-v7.3.0/Problems -type f -name "*.p" | cabal run TestImportExportImportFile -- False
 
  - cabal sdist   # tests that a source-distribution can be generated
 

--- a/logic-TPTP.cabal
+++ b/logic-TPTP.cabal
@@ -96,6 +96,7 @@ Executable TestImportExportImportFile
  build-depends:     logic-TPTP
                   , base
                   , ansi-wl-pprint
+                  , optparse-applicative >=0.11 && <0.16
                   , pcre-light
                   , semigroups
  if impl(ghc <7.10)

--- a/testing/TestImportExportImportFile.hs
+++ b/testing/TestImportExportImportFile.hs
@@ -4,13 +4,29 @@ module Main where
 
 import Control.Monad
 import Data.Monoid
-import Text.PrettyPrint.ANSI.Leijen
+import Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
 import System.Exit
 import Common
-import SimpleArgs
+import Options.Applicative
 
 import "logic-TPTP" Codec.TPTP
 
+data Options
+  = Options
+  { optPrintExport :: Bool
+  }
+
+optionsParser :: Parser Options
+optionsParser = Options <$> printExportOption
+  where
+    printExportOption = argument auto
+      $  metavar "True|False"
+      <> help ("print exported result")
+
+parserInfo :: ParserInfo Options
+parserInfo = info (helper <*> optionsParser) $ mconcat
+  [ fullDesc
+  ]
 
 -- Note: This test expects a list of .p files (one per line) through stdin
 
@@ -18,7 +34,7 @@ main ::  IO ()
 main = do
   files <- lines `fmap` getContents
   --print (length files)
-  print_export <- getArgs
+  Options print_export <- execParser parserInfo
   forM_ files (diff_once_twice print_export)
   exitWith ExitSuccess
 


### PR DESCRIPTION
This PR is a continuation of #15 and makes `TestImportExportImportFile` to be run on Travis-CI.

Do not merge it for now, because it runs out of memory on Travis-CI.