### PR TITLE
Optimization using bytestring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ before_cache:
 
 matrix:
   include:
-    - env: CABALVER=1.18 GHCVER=7.8.4
-      compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
     - env: CABALVER=1.22 GHCVER=7.10.3
       compiler: ": #GHC 7.10.3"
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}

--- a/Codec/TPTP/Export.hs
+++ b/Codec/TPTP/Export.hs
@@ -14,13 +14,14 @@ import Data.Monoid hiding (All (..))
 import Data.Ratio
 import qualified Data.ByteString.Lazy.Char8 as BL
 import qualified Data.ByteString.Lazy.Builder as Builder
+import qualified Data.ByteString.Lazy.UTF8 as UTF8
 
 
 toTPTP :: forall a. (ToTPTP a) => a -> ShowS
 toTPTP a s = toTPTP' a ++ s
 
 toTPTP' :: forall a. (ToTPTP a) => a -> String
-toTPTP' = BL.unpack . toTPTPByteString -- TODO: handle UTF-8
+toTPTP' = UTF8.toString . toTPTPByteString
 
 toTPTPByteString :: forall a. (ToTPTP a) => a -> BL.ByteString
 toTPTPByteString = Builder.toLazyByteString . toTPTPBuilder

--- a/Codec/TPTP/Import.hs
+++ b/Codec/TPTP/Import.hs
@@ -1,9 +1,11 @@
 {-# OPTIONS -Wall #-}
-module Codec.TPTP.Import(parse,parseFile
-                        ,parseWithComment,parseWithCommentFile
+module Codec.TPTP.Import(parse,parseByteString,parseFile
+                        ,parseWithComment,parseWithCommentByteString,parseWithCommentFile
                         ,Token(..)) where
 
 
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.ByteString.Lazy.Builder as Builder
 import Lexer
 import Parser
 import ParserC
@@ -11,14 +13,20 @@ import Codec.TPTP.Base
 
 
 parse :: String -> [TPTP_Input]
-parse = parseTPTP . map snd . alexScanTokens
+parse = parseByteString . Builder.toLazyByteString . Builder.stringUtf8
+
+parseByteString :: BL.ByteString -> [TPTP_Input]
+parseByteString = parseTPTP . map snd . alexScanTokens
 
 parseFile :: FilePath -> IO [TPTP_Input]
-parseFile x = parse `fmap` readFile x
+parseFile x = parseByteString `fmap` BL.readFile x
 
 
 parseWithComment :: String -> [TPTP_Input_C]
-parseWithComment = parseTPTPwithComment . map snd . alexScanTokens
+parseWithComment = parseWithCommentByteString . Builder.toLazyByteString . Builder.stringUtf8
+
+parseWithCommentByteString :: BL.ByteString -> [TPTP_Input_C]
+parseWithCommentByteString = parseTPTPwithComment . map snd . alexScanTokens
 
 parseWithCommentFile :: FilePath -> IO [TPTP_Input_C]
-parseWithCommentFile x = parseWithComment `fmap` readFile x
+parseWithCommentFile x = parseWithCommentByteString `fmap` BL.readFile x

--- a/Lexer.x
+++ b/Lexer.x
@@ -8,7 +8,6 @@
 module Lexer where
 import Data.Ratio
 import qualified Data.ByteString.Lazy.Char8 as BL
-import qualified Data.ByteString.Lazy.UTF8 as UTF8
 }
 
 %wrapper "posn-bytestring"
@@ -46,16 +45,16 @@ tokens :-
   ")"                                          { withPos $ const RP }
   ","                                          { withPos $ const Comma }
   "!="|"="|"<=>"|"<="|"=>"|"<~>"|"&"|"|"
-      |"~|"|"~&"|"!"|"?"|":"|"~"               { withPos $ Oper . UTF8.toString }
+      |"~|"|"~&"|"!"|"?"|":"|"~"               { withPos Oper }
   "."                                          { withPos $ const Dot }
-  ("%"|"#")$printable_char*                    { withPos $ CommentToken . UTF8.toString } -- comment line
-  "/*" @not_star_slash "*"("*"*)"/"            { withPos $ CommentToken . UTF8.toString } -- comment block
-  [\'] @sq_char* [\']                          { withPos $ SingleQuoted . UTF8.toString }
-  [\"] @do_char* [\"]                          { withPos $ DoubleQuoted . UTF8.toString }
-  $dollar $dollar $lower_alpha $alpha_numeric* { withPos $ DollarDollarWord . UTF8.toString }
-  $dollar $lower_alpha $alpha_numeric*         { withPos $ DollarWord . UTF8.toString }
-  $upper_alpha $alpha_numeric*                 { withPos $ UpperWord . UTF8.toString }
-  $lower_alpha $alpha_numeric*                 { withPos $ LowerWord . UTF8.toString }
+  ("%"|"#")$printable_char*                    { withPos CommentToken } -- comment line
+  "/*" @not_star_slash "*"("*"*)"/"            { withPos CommentToken } -- comment block
+  [\'] @sq_char* [\']                          { withPos SingleQuoted }
+  [\"] @do_char* [\"]                          { withPos DoubleQuoted }
+  $dollar $dollar $lower_alpha $alpha_numeric* { withPos DollarDollarWord }
+  $dollar $lower_alpha $alpha_numeric*         { withPos DollarWord }
+  $upper_alpha $alpha_numeric*                 { withPos UpperWord }
+  $lower_alpha $alpha_numeric*                 { withPos LowerWord }
   "*"                                          { withPos $ const Star }
   "+"                                          { withPos $ const Plus }
   ">"                                          { withPos $ const Rangle }
@@ -82,20 +81,20 @@ data Token =
          | Dot
          | Lbrack
          | Rbrack
-         | Oper String
-         | SingleQuoted String
-         | DoubleQuoted String
-         | DollarWord String
-         | DollarDollarWord String
-         | UpperWord String
-         | LowerWord String
+         | Oper BL.ByteString
+         | SingleQuoted BL.ByteString
+         | DoubleQuoted BL.ByteString
+         | DollarWord BL.ByteString
+         | DollarDollarWord BL.ByteString
+         | UpperWord BL.ByteString
+         | LowerWord BL.ByteString
          | Star
          | Plus
          | Rangle
          | SignedInt Integer
          | UnsignedInt Integer
          | Real Rational
-         | CommentToken String
+         | CommentToken BL.ByteString
          | Slash
     deriving (Eq,Ord,Show)
 

--- a/Lexer.x
+++ b/Lexer.x
@@ -7,6 +7,7 @@
 module Lexer where
 import Data.Ratio
 import qualified Data.ByteString.Lazy.Char8 as BL
+import qualified Data.ByteString.Lazy.UTF8 as UTF8
 }
 
 %wrapper "posn-bytestring"
@@ -70,7 +71,7 @@ tokens :-
 {
 -- Each action has type :: String -> Token
 
-withPos f pos s = (pos, f (BL.unpack s)) -- TODO: handle UTF-8
+withPos f pos s = (pos, f (UTF8.toString s))
 
 -- The token type:
 data Token =

--- a/Lexer.x
+++ b/Lexer.x
@@ -6,9 +6,10 @@
 
 module Lexer where
 import Data.Ratio
+import qualified Data.ByteString.Lazy.Char8 as BL
 }
 
-%wrapper "posn"
+%wrapper "posn-bytestring"
 
 $sign = [\+\-]
 $exponent = [Ee]
@@ -69,7 +70,7 @@ tokens :-
 {
 -- Each action has type :: String -> Token
 
-withPos f pos s = (pos, f s)
+withPos f pos s = (pos, f (BL.unpack s)) -- TODO: handle UTF-8
 
 -- The token type:
 data Token =

--- a/Parser.y
+++ b/Parser.y
@@ -1,4 +1,5 @@
 {
+{-# LANGUAGE OverloadedStrings #-}
 module Parser where
 
 import Data.Char
@@ -12,6 +13,7 @@ import Codec.TPTP.Base
 import System.IO
 import System.IO.Unsafe
 import Control.Monad.Identity
+import qualified Data.ByteString.Lazy.UTF8 as UTF8
 }
 
 %name parseTPTP
@@ -80,7 +82,7 @@ TPTP_file  : {[]} | TPTP_input TPTP_file  {$1 : $2}
 TPTP_input  :: {TPTP_Input}
 TPTP_input  : annotated_formula  {$1}
              | include  { $1 }
-             | comment { Comment $1 }
+             | comment { Comment (UTF8.toString $1) }
 
 annotated_formula  :: {TPTP_Input}
 annotated_formula  :  fof_annotated  {$1}
@@ -475,17 +477,17 @@ include_           :: {Token}
 include_           : tok_include_            comment_list { $1 }
 
 single_quoted      :: {String}
-single_quoted      : tok_single_quoted       comment_list { $1 }
+single_quoted      : tok_single_quoted       comment_list { UTF8.toString $1 }
 distinct_object    :: {String}
-distinct_object    : tok_distinct_object     comment_list { $1 }
+distinct_object    : tok_distinct_object     comment_list { UTF8.toString $1 }
 dollar_word        :: {String}
-dollar_word        : tok_dollar_word         comment_list { $1 }
+dollar_word        : tok_dollar_word         comment_list { UTF8.toString $1 }
 dollar_dollar_word :: {String}
-dollar_dollar_word : tok_dollar_dollar_word  comment_list { $1 }
+dollar_dollar_word : tok_dollar_dollar_word  comment_list { UTF8.toString $1 }
 upper_word         :: {String}
-upper_word         : tok_upper_word          comment_list { $1 }
+upper_word         : tok_upper_word          comment_list { UTF8.toString $1 }
 lower_word         :: {String}
-lower_word         : tok_lower_word          comment_list { $1 }
+lower_word         : tok_lower_word          comment_list { UTF8.toString $1 }
 signed_integer     :: {Integer}
 signed_integer     : tok_signed_integer      comment_list { $1 }
 unsigned_integer   :: {Integer}
@@ -494,7 +496,7 @@ real               :: {Rational}
 real               : tok_real                comment_list { $1 }
 
 comment_list :: {[String]}
-comment_list : {[]} | comment comment_list { $1 : $2 }
+comment_list : {[]} | comment comment_list { UTF8.toString $1 : $2 }
 
 {
 

--- a/ParserC.y
+++ b/ParserC.y
@@ -1,4 +1,5 @@
 {
+{-# LANGUAGE OverloadedStrings #-}
 module ParserC where
 
 import Data.Char
@@ -13,6 +14,7 @@ import System.IO
 import System.IO.Unsafe
 import Control.Monad.Identity
 import Control.Monad.State
+import qualified Data.ByteString.Lazy.UTF8 as UTF8
 }
 
 %name parseTPTPwithComment
@@ -81,7 +83,7 @@ TPTP_file  : {[]} | TPTP_input TPTP_file  {$1 : $2}
 TPTP_input  :: {TPTP_Input_C}
 TPTP_input  : annotated_formula  {$1}
              | include  { $1 }
-             | comment { Comment $1 }
+             | comment { Comment (UTF8.toString $1) }
 
 annotated_formula  :: {TPTP_Input_C}
 annotated_formula  :  fof_annotated  {$1}
@@ -475,17 +477,17 @@ include_           :: {Token}
 include_           : tok_include_            comment_list { $1 }
 
 single_quoted      :: {String}
-single_quoted      : tok_single_quoted       comment_list { $1 }
+single_quoted      : tok_single_quoted       comment_list { UTF8.toString $1 }
 distinct_object    :: {String}
-distinct_object    : tok_distinct_object     comment_list { $1 }
+distinct_object    : tok_distinct_object     comment_list { UTF8.toString $1 }
 dollar_word        :: {String}
-dollar_word        : tok_dollar_word         comment_list { $1 }
+dollar_word        : tok_dollar_word         comment_list { UTF8.toString $1 }
 dollar_dollar_word :: {String}
-dollar_dollar_word : tok_dollar_dollar_word  comment_list { $1 }
+dollar_dollar_word : tok_dollar_dollar_word  comment_list { UTF8.toString $1 }
 upper_word         :: {String}
-upper_word         : tok_upper_word          comment_list { $1 }
+upper_word         : tok_upper_word          comment_list { UTF8.toString $1 }
 lower_word         :: {String}
-lower_word         : tok_lower_word          comment_list { $1 }
+lower_word         : tok_lower_word          comment_list { UTF8.toString $1 }
 signed_integer     :: {Integer}
 signed_integer     : tok_signed_integer      comment_list { $1 }
 unsigned_integer   :: {Integer}
@@ -494,7 +496,7 @@ real               :: {Rational}
 real               : tok_real                comment_list { $1 }
 
 comment_list :: {[String]}
-comment_list : {[]} | comment comment_list { $1 : $2 }
+comment_list : {[]} | comment comment_list { UTF8.toString $1 : $2 }
 
 {
 data AToken = AToken { tok :: Token, comm :: [String] }

--- a/ParserC.y
+++ b/ParserC.y
@@ -14,7 +14,9 @@ import System.IO
 import System.IO.Unsafe
 import Control.Monad.Identity
 import Control.Monad.State
-import qualified Data.ByteString.Lazy.UTF8 as UTF8
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Lazy.Char8 as BL
+import qualified Data.ByteString.UTF8 as UTF8
 }
 
 %name parseTPTPwithComment
@@ -83,7 +85,7 @@ TPTP_file  : {[]} | TPTP_input TPTP_file  {$1 : $2}
 TPTP_input  :: {TPTP_Input_C}
 TPTP_input  : annotated_formula  {$1}
              | include  { $1 }
-             | comment { Comment (UTF8.toString $1) }
+             | comment { Comment (UTF8.toString (BL.toStrict $1)) }
 
 annotated_formula  :: {TPTP_Input_C}
 annotated_formula  :  fof_annotated  {$1}
@@ -103,7 +105,7 @@ annotations  :  comma source optional_info  { Annotations $2 $3 }
     | { NoAnnotations }
 
 formula_role  :: {Role}
-formula_role  : lower_word_ { Role $1 }
+formula_role  : lower_word_ { Role' $1 }
 
 
 fof_formula  :: {FormulaC}
@@ -277,35 +279,35 @@ defined_term  : defined_atom {$1}
 
 defined_atom  :: {TermC}
 defined_atom  : number {numberLitTerm $1}
-               | distinct_object {distinctObjectTerm (stripQuotes '"' $1)}
+               | distinct_object {distinctObjectTerm' (stripQuotes '"' $1)}
 
 defined_atomic_term :: {TermC}
 defined_atomic_term  : defined_plain_term {$1}
 
 defined_plain_term  :: {TermC}
-defined_plain_term  : defined_constant {fApp (AtomicWord $1) []}
-                     | defined_functor  lp arguments  rp {fApp (AtomicWord $1) $3}
+defined_plain_term  : defined_constant {fApp (AtomicWord' $1) []}
+                     | defined_functor  lp arguments  rp {fApp (AtomicWord' $1) $3}
 
-defined_constant  :: {String}
+defined_constant  :: {BS.ByteString}
 defined_constant  : defined_functor {$1}
 -- defined_constant  :==
 
-defined_functor  :: {String}
+defined_functor  :: {BS.ByteString}
 defined_functor  : atomic_defined_word {$1}
 -- defined_functor  :==
 
 system_term  :: {TermC}
-system_term  :  system_constant  {fApp (AtomicWord $1) []}
-              | system_functor  lp arguments  rp {fApp (AtomicWord $1) $3}
+system_term  :  system_constant  {fApp (AtomicWord' $1) []}
+              | system_functor  lp arguments  rp {fApp (AtomicWord' $1) $3}
 
-system_constant  :: {String}
+system_constant  :: {BS.ByteString}
 system_constant  : system_functor  {$1}
 
-system_functor  :: {String}
+system_functor  :: {BS.ByteString}
 system_functor  : atomic_system_word {$1}
 
 variable  :: {V}
-variable  : upper_word {V $1}
+variable  : upper_word {V' $1}
 
 arguments  :: {[TermC]}
 arguments  : term  {[$1]}
@@ -375,7 +377,7 @@ general_data  :  atomic_word  { GWord $1 }
                | atomic_word  lp general_terms  rp { GApp $1 $3 }
                | variable  { GVar $1 }
                | number  { GNumber $1 }
-               | distinct_object { GDistinctObject (stripQuotes '"' $1) }
+               | distinct_object { GDistinctObject' (stripQuotes '"' $1) }
                | formula_data  { $1 }
 
 formula_data :: {GData}
@@ -393,16 +395,16 @@ general_terms  :  general_term  {[$1]}
 
 name  :: {AtomicWord}
 name  : atomic_word  {$1}
-       | unsigned_integer {AtomicWord(show $1)}
+       | unsigned_integer {AtomicWord' (BS.pack (show $1))}
 
 atomic_word  :: {AtomicWord}
-atomic_word  : lower_word_ {AtomicWord $1}
-              | single_quoted{AtomicWord (stripQuotes '\'' $1)}
+atomic_word  : lower_word_ {AtomicWord' $1}
+              | single_quoted{AtomicWord' (stripQuotes '\'' $1)}
 
-atomic_defined_word  :: {String}
+atomic_defined_word  :: {BS.ByteString}
 atomic_defined_word  : dollar_word{$1}
 
-atomic_system_word  :: {String}
+atomic_system_word  :: {BS.ByteString}
 atomic_system_word  : dollar_dollar_word{$1}
 
 number  :: {Rational} -- maybe keep track of the number type that was actually parsed
@@ -415,9 +417,9 @@ rational :: {Rational}
 rational : integer tok_slash unsigned_integer {$1 % $3}
 
 file_name  :: {String}
-file_name  : single_quoted {stripQuotes '\'' $1}
+file_name  : single_quoted {UTF8.toString (stripQuotes '\'' $1)}
 
-lower_word_ :: {String}
+lower_word_ :: {BS.ByteString}
 lower_word_ : lower_word {$1} | fof {"fof"} | cnf {"cnf"} | include_ {"include"} -- "fof" is a perfectly cromulent lower_word, but it is interpreted as a "fof" token
 
 lp                 :: {Token}
@@ -476,18 +478,18 @@ cnf                : tok_cnf                 comment_list { $1 }
 include_           :: {Token}
 include_           : tok_include_            comment_list { $1 }
 
-single_quoted      :: {String}
-single_quoted      : tok_single_quoted       comment_list { UTF8.toString $1 }
-distinct_object    :: {String}
-distinct_object    : tok_distinct_object     comment_list { UTF8.toString $1 }
-dollar_word        :: {String}
-dollar_word        : tok_dollar_word         comment_list { UTF8.toString $1 }
-dollar_dollar_word :: {String}
-dollar_dollar_word : tok_dollar_dollar_word  comment_list { UTF8.toString $1 }
-upper_word         :: {String}
-upper_word         : tok_upper_word          comment_list { UTF8.toString $1 }
-lower_word         :: {String}
-lower_word         : tok_lower_word          comment_list { UTF8.toString $1 }
+single_quoted      :: {BS.ByteString}
+single_quoted      : tok_single_quoted       comment_list { BL.toStrict $1 }
+distinct_object    :: {BS.ByteString}
+distinct_object    : tok_distinct_object     comment_list { BL.toStrict $1 }
+dollar_word        :: {BS.ByteString}
+dollar_word        : tok_dollar_word         comment_list { BL.toStrict $1 }
+dollar_dollar_word :: {BS.ByteString}
+dollar_dollar_word : tok_dollar_dollar_word  comment_list { BL.toStrict $1 }
+upper_word         :: {BS.ByteString}
+upper_word         : tok_upper_word          comment_list { BL.toStrict $1 }
+lower_word         :: {BS.ByteString}
+lower_word         : tok_lower_word          comment_list { BL.toStrict $1 }
 signed_integer     :: {Integer}
 signed_integer     : tok_signed_integer      comment_list { $1 }
 unsigned_integer   :: {Integer}
@@ -496,7 +498,7 @@ real               :: {Rational}
 real               : tok_real                comment_list { $1 }
 
 comment_list :: {[String]}
-comment_list : {[]} | comment comment_list { UTF8.toString $1 : $2 }
+comment_list : {[]} | comment comment_list { UTF8.toString (BL.toStrict $1) : $2 }
 
 {
 data AToken = AToken { tok :: Token, comm :: [String] }
@@ -511,7 +513,7 @@ instance Commented (State [String]) where
   withComments (F mf) s = F $ do { f <- mf; put s; return f }
 
 
-stripQuotes which (x:xs) = go xs
+stripQuotes which xs = BS.pack $ go $ BS.unpack (BS.tail xs)
                       where
                         go [x] = []
                         go ('\\':'\\':xs) = '\\':go xs

--- a/logic-TPTP.cabal
+++ b/logic-TPTP.cabal
@@ -43,7 +43,6 @@ tested-with: GHC==8.4.4
 tested-with: GHC==8.2.2
 tested-with: GHC==8.0.2
 tested-with: GHC==7.10.3
-tested-with: GHC==7.8.4
 
 source-repository head
  type: git
@@ -59,7 +58,7 @@ Flag BuildTestPrograms
 Library
  ghc-options: -Wall -O2
 
- build-depends:      base >=4 && < 5
+ build-depends:      base >=4.8 && < 5
                    , array
                    , bytestring
                    , syb

--- a/logic-TPTP.cabal
+++ b/logic-TPTP.cabal
@@ -71,6 +71,7 @@ Library
                    , semigroups
                    , transformers
                    , transformers-compat >= 0.5
+                   , utf8-string
 
  exposed-modules:   Codec.TPTP.Import
                   , Codec.TPTP.Base

--- a/logic-TPTP.cabal
+++ b/logic-TPTP.cabal
@@ -61,6 +61,7 @@ Library
 
  build-depends:      base >=4 && < 5
                    , array
+                   , bytestring
                    , syb
                    , containers
                    , ansi-wl-pprint
@@ -95,6 +96,7 @@ Executable TestImportExportImportFile
  hs-source-dirs:    testing
  build-depends:     logic-TPTP
                   , base
+                  , bytestring
                   , ansi-wl-pprint
                   , optparse-applicative >=0.11 && <0.16
                   , pcre-light
@@ -112,6 +114,7 @@ Test-suite TestImportExportRandom
  hs-source-dirs:    testing
  build-depends:     logic-TPTP
                   , base
+                  , bytestring
                   , ansi-wl-pprint
                   , pcre-light
                   , QuickCheck

--- a/testing/Common.hs
+++ b/testing/Common.hs
@@ -4,9 +4,11 @@
 
 module Common where
 
+import qualified Data.ByteString.Char8 as BS
 import Data.Monoid
 import qualified Data.Semigroup as Semigroup
 import Text.PrettyPrint.ANSI.Leijen
+import qualified Text.Regex.PCRE.Light as PCRE
 import Text.Regex.PCRE.Light.Char8
 import Codec.TPTP
 
@@ -53,3 +55,8 @@ findUnsupportedFormulaType ::  String -> Maybe String
 findUnsupportedFormulaType =
     let re = compile "^(thf|tff)\\(" [multiline]
     in (\x -> (!!1) `fmap` match re x [])
+
+findUnsupportedFormulaTypeByteString ::  BS.ByteString -> Maybe BS.ByteString
+findUnsupportedFormulaTypeByteString =
+    let re = PCRE.compile (BS.pack "^(thf|tff)\\(") [multiline]
+    in (\x -> (!!1) `fmap` PCRE.match re x [])

--- a/testing/TestImportExportImportFile.hs
+++ b/testing/TestImportExportImportFile.hs
@@ -2,6 +2,8 @@
 module Main where
 
 import Control.Monad
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Lazy.Char8 as BL
 import Data.Monoid
 import Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
 import System.Exit
@@ -45,18 +47,18 @@ diff_once_twice ::  Bool -> Bool -> String -> IO ()
 diff_once_twice print_export print_failure_only infilename'  = do
   --let tmp = "/tmp/tmp.tptp"
   unless print_failure_only $ putStrLn infilename'
-  input <- readFile infilename'
-  case findUnsupportedFormulaType input of
+  input <- BS.readFile infilename'
+  case findUnsupportedFormulaTypeByteString input of
      Just x -> do
        unless print_failure_only $ 
-         putStrLn . prettySimple . yellow . text $ ("Skipping unsupported formula type "++x)
+         putStrLn . prettySimple . yellow . text $ ("Skipping unsupported formula type "++BS.unpack x)
      Nothing -> do
 
-      let once = parse input
-      let tptp = toTPTP' once
+      let once = parseByteString (BL.fromStrict input)
+      let tptp = toTPTPByteString once
       when (print_export && not print_failure_only) $
-        putStrLn $ "new tptp = " ++tptp
-      let twice = parse tptp
+        BL.putStrLn $ BL.pack "new tptp = " <> tptp
+      let twice = parseByteString tptp
       let dif = mconcat (zipWith diffAFormula once twice)
       let success = (putStrLn . prettySimple . dullgreen . text $ "Ok")
 


### PR DESCRIPTION
Attempt for optimization using bytestring (#24).

* read file as lazy `ByteString` and feed it to `Alex` directly without going through `String` (Note that `Alex` internally uses UTF-8),
* dump formula into bytestring `Builder` instead of `ShowS`.
* use ByteString for internal representation for some types (`V`, `AtomicWord`, `Role`, `DistinctObjectTerm`)

Compatibility is kept to some extent using `PatternSynonyms` extension. 

As I show below, maximum residency is reduced significantly, but I'm still not sure if it is worth its implementation complexity.

# Experiments

I compiled `TestImportExportImportFile` using GHC 8.6.5 + Stackage LTS 14.20 using `stack build --executable-profiling --flag logic-TPTP:BuildTestPrograms`, and ran `echo TPTP-v7.3.0/Problems/HWV/HWV122-1.p | TestImportExportImportFile False +RTS -p -s` on `master` (4ef0ec9cc5bc8124a2d8134c20ad8a16cda5cb39) and on this `bytestring` branch (6cb34a61b3da55af59d2b0bfa4afb566fb5440d4) three times for each and take average of profile information.

## Result

Time/allocation profile (`-p`):

|       |before|after|
|----|-------|-----|
|total time|11.14 secs|10.66 secs|
|total alloc (excludes profiling overheads)|6,864,859,344 bytes|7,661,934,288 bytes|

Summary  GC statistics (`-s`):

|       |before|after|
|----|-------|-----|
|allocated in the heap| 11,053,555,346 bytes|12,196,062,090 bytes|
|copied during GC|2,644,563,434 bytes|2,403,806,042 bytes|
|maximum residency|459,088,146 bytes|266,768,733 bytes|
|maximum slop|2,519,392 bytes|2,328,909 bytes|
|total memory in use|437 MB|254 MB|

## Discussion

Total allocation increased a little (+11.6 %). I guess this is caused by increased conversion between types.

On the other hands, maximum residency is reduced significantly (-41.9 %).

Execution time is reduced a little (-4.3 %), but this may be by chance.

