### PR TITLE
Fix cabal warnings

### DIFF
--- a/logic-TPTP.cabal
+++ b/logic-TPTP.cabal
@@ -1,6 +1,6 @@
 name: logic-TPTP
 version: 0.5.0.0
-cabal-version: >= 1.8
+cabal-version: >= 1.10
 build-type: Simple
 license: GPL
 license-file: LICENSE
@@ -84,6 +84,7 @@ Library
                   , Util
 
  build-tools: alex >= 3.1.1, happy >= 1.19.1
+ default-language:  Haskell2010
 
 
 Executable TestImportExportImportFile
@@ -99,6 +100,7 @@ Executable TestImportExportImportFile
                   , semigroups
  if impl(ghc <7.10)
   build-depends:    pcre-light <0.4.1
+ default-language:  Haskell2010
  other-extensions:  CPP
  if !flag(BuildTestPrograms)
   buildable: False
@@ -118,6 +120,7 @@ Test-suite TestImportExportRandom
                   , transformers-compat >= 0.5
  if impl(ghc <7.10)
   build-depends:    pcre-light <0.4.1
+ default-language:  Haskell2010
  other-extensions:  CPP
 
 Executable PrettyPrintFile
@@ -138,6 +141,7 @@ Executable PrettyPrintFile
                   , syb
  if impl(ghc <7.10)
   build-depends:    pcre-light <0.4.1
+ default-language:  Haskell2010
  other-extensions:  CPP
  if !flag(BuildTestPrograms)
   buildable: False
@@ -160,6 +164,7 @@ Executable ParseRandom
                   , syb
  if impl(ghc <7.10)
   build-depends:    pcre-light <0.4.1
+ default-language:  Haskell2010
  other-extensions:  CPP
  if !flag(BuildTestPrograms)
   buildable: False


### PR DESCRIPTION
* The field "other-extensions" is available only since the Cabal specification version 1.10.

* Packages using 'cabal-version: >= 1.10' and before 'cabal-version: 3.4' must specify the 'default-language' field for each component.