### PR TITLE
restrict ansi-wl-pprint to <1.0 since ansi-wl-pprint-1.0.2 is incompatible with current logic-TPTP

### DIFF
--- a/logic-TPTP.cabal
+++ b/logic-TPTP.cabal
@@ -61,7 +61,7 @@ Library
                    , array
                    , syb
                    , containers
-                   , ansi-wl-pprint
+                   , ansi-wl-pprint < 1.0
                    , QuickCheck >= 2
                    , mtl
                    , pointed


### PR DESCRIPTION
ref #30