### PR TITLE
Fix an -Woperator-whitespace-ext-conflict warning

### DIFF
--- a/Codec/TPTP/Export.hs
+++ b/Codec/TPTP/Export.hs
@@ -13,7 +13,7 @@ import Data.Ratio
 
 -- | Convenient wrapper for 'toTPTP'
 toTPTP' :: forall a. (ToTPTP a) => a -> String
-toTPTP' = ($"") . toTPTP
+toTPTP' = ($ "") . toTPTP
 
 s :: String -> String -> String
 s = showString


### PR DESCRIPTION
This fixes the following error:

```
/logic-TPTP/Codec/TPTP/Export.hs:16:12: warning: [-Woperator-whitespace-ext-conflict]
    The prefix use of a ‘$’ would denote an untyped splice
      were the TemplateHaskell extension enabled.
    Suggested fix: Add whitespace after the ‘$’.
   |
16 | toTPTP' = ($"") . toTPTP
   |            ^
```