### PR TITLE
Drop GHC <7.10 support

### DIFF
--- a/Codec/TPTP/Base.hs
+++ b/Codec/TPTP/Base.hs
@@ -34,10 +34,6 @@ import Data.Copointed
 import Control.Monad.Trans.Instances () -- Import Eq,Ord,Show,Read,Data,Typeable orphan instances for Data.Functor.Identity from transformers-compat package
 #endif
 
-#if !MIN_VERSION_base(4,7,0)
-import Util
-#endif
-
 -- * Basic undecorated formulae and terms
 
 -- | Basic (undecorated) first-order formulae
@@ -258,15 +254,8 @@ deriving instance Ord (c (Formula0 (T c) (F c))) => Ord (TPTP_Input_ c)
 deriving instance Show (c (Formula0 (T c) (F c))) => Show (TPTP_Input_ c)
 deriving instance Read (c (Formula0 (T c) (F c))) => Read (TPTP_Input_ c)
 
-
-#if MIN_VERSION_base(4,7,0)
 deriving instance (Typeable c, Data (c (Formula0 (T c) (F c)))) => Data (TPTP_Input_ c)
 deriving instance Typeable TPTP_Input_
-#else
-deriving instance (Typeable1 c, Data (c (Formula0 (T c) (F c)))) => Data (TPTP_Input_ c)
-instance Typeable1 c => Typeable (TPTP_Input_ c) where
-  typeOf = mkTypeOfForRank2Kind "Codec.TPTP.Base" "TPTP_Input_"
-#endif
 
 -- | Annotations about the formulas origin
 data Annotations = NoAnnotations | Annotations GTerm UsefulInfo
@@ -607,22 +596,11 @@ DI(Ord)
 DI(Show)
 DI(Read)
 
-#if MIN_VERSION_base(4,7,0)
 deriving instance Typeable F
 deriving instance Typeable T
 
 deriving instance (Typeable c, Data (c (Term0 (T c)))) => Data (T c)
 deriving instance (Typeable c, Data (c (Formula0 (T c) (F c)))) => Data (F c)
-#else
-instance Typeable1 c => Typeable (F c) where
-    typeOf = mkTypeOfForRank2Kind "Codec.TPTP.Base" "F"
-
-instance Typeable1 c => Typeable (T c) where
-    typeOf = mkTypeOfForRank2Kind "Codec.TPTP.Base" "T"
-
-deriving instance (Typeable1 c, Data (c (Term0 (T c)))) => Data (T c)
-deriving instance (Typeable1 c, Data (c (Formula0 (T c) (F c)))) => Data (F c)
-#endif
 
 -- * Utility functions
 

--- a/Codec/TPTP/Base.hs
+++ b/Codec/TPTP/Base.hs
@@ -2,7 +2,7 @@
   , StandaloneDeriving
   , TypeSynonymInstances, FlexibleInstances, FlexibleContexts
   , UndecidableInstances, DeriveDataTypeable, GeneralizedNewtypeDeriving
-  , OverlappingInstances, ScopedTypeVariables
+  , ScopedTypeVariables
   #-}
 
 module Codec.TPTP.Base where

--- a/Codec/TPTP/Diff.hs
+++ b/Codec/TPTP/Diff.hs
@@ -2,7 +2,7 @@
   , StandaloneDeriving, MultiParamTypeClasses, FunctionalDependencies
   , TypeSynonymInstances, FlexibleInstances, FlexibleContexts
   , UndecidableInstances, DeriveDataTypeable, GeneralizedNewtypeDeriving
-  , OverlappingInstances, OverloadedStrings, RankNTypes
+  , OverloadedStrings, RankNTypes
   #-}
 {-# OPTIONS -Wall #-}
 
@@ -195,10 +195,10 @@ diffFormula (F (Identity f1)) (F (Identity f2)) = F $
       _ -> let plug=plugSubformulae (T DontCare) (F DontCare) in Differ (plug f1) (plug f2)
 
 
-instance Show (T DiffResult) where
+instance {-# OVERLAPPING #-} Show (T DiffResult) where
     show (T t) = show t
 
-instance Show (F DiffResult) where
+instance {-# OVERLAPPING #-} Show (F DiffResult) where
     show (F f) = show f
 
 type T0Diff = DiffResult (Term0 (T DiffResult))

--- a/Codec/TPTP/Diff.hs
+++ b/Codec/TPTP/Diff.hs
@@ -11,9 +11,7 @@ module Codec.TPTP.Diff(Diffable(..),DiffResult(..),T0Diff,F0Diff,isSame,diffGenF
 
 -- Warning: This module is a MESS (but it seems to work :)).
 
-#if MIN_VERSION_base(4,8,0)
 import Prelude hiding ((<$>))
-#endif
 
 import Data.Generics
 import Test.QuickCheck hiding((.&.))

--- a/Codec/TPTP/Export.hs
+++ b/Codec/TPTP/Export.hs
@@ -2,7 +2,7 @@
   , StandaloneDeriving
   , TypeSynonymInstances, FlexibleInstances, FlexibleContexts
   , UndecidableInstances, DeriveDataTypeable, GeneralizedNewtypeDeriving
-  , OverlappingInstances, RankNTypes
+  , RankNTypes
   #-}
 {-# OPTIONS -Wall #-}
 module Codec.TPTP.Export(toTPTP',ToTPTP(..),isLowerWord) where

--- a/Codec/TPTP/Pretty.hs
+++ b/Codec/TPTP/Pretty.hs
@@ -2,7 +2,7 @@
   , StandaloneDeriving
   , TypeSynonymInstances, FlexibleInstances, FlexibleContexts
   , UndecidableInstances, DeriveDataTypeable, GeneralizedNewtypeDeriving
-  , OverlappingInstances, RankNTypes, PatternGuards
+  , RankNTypes, PatternGuards
   #-}
 
 {-# OPTIONS -Wall -fno-warn-orphans #-}

--- a/Codec/TPTP/Pretty.hs
+++ b/Codec/TPTP/Pretty.hs
@@ -10,9 +10,7 @@
 -- | Mainly just 'Pretty' instances
 module Codec.TPTP.Pretty(prettySimple,WithEnclosing(..),Enclosing(..)) where
 
-#if MIN_VERSION_base(4,8,0)
 import Prelude hiding ((<$>))
-#endif
 
 import Codec.TPTP.Base
 import Codec.TPTP.Export

--- a/Codec/TPTP/QuickCheck.hs
+++ b/Codec/TPTP/QuickCheck.hs
@@ -2,7 +2,7 @@
   , StandaloneDeriving
   , TypeSynonymInstances, FlexibleInstances, FlexibleContexts
   , UndecidableInstances, DeriveDataTypeable, GeneralizedNewtypeDeriving
-  , OverlappingInstances, RankNTypes, PatternGuards
+  , RankNTypes, PatternGuards
   #-}
 {-# OPTIONS -Wall #-}
 module Codec.TPTP.QuickCheck where

--- a/Util.hs
+++ b/Util.hs
@@ -6,26 +6,3 @@ module Util where
 #ifndef MIN_VERSION_base
 #define MIN_VERSION_base(X,Y,Z) 1
 #endif
-
-#if !MIN_VERSION_base(4,7,0)
-import Data.Typeable
-
-#if ! MIN_VERSION_base(4,4,0)
-mkTyCon3 _ m t = mkTyCon $ m++"."++t
-#endif
-
-packageName :: String
-packageName = "logic-TPTP"
-
-
--- | Gets the TypeRep of @c@ (not of @c ()@)
-getTyRep1 :: forall c. Typeable1 c => c () -> TypeRep
-getTyRep1 _ = mkTyConApp (typeRepTyCon (typeOf1 (undefined :: c ()))) []
-
-
-mkTypeOfForRank2Kind :: forall x c. Typeable1 c => String -> String -> x c -> TypeRep
-mkTypeOfForRank2Kind moduleName typeName = const tr
-    where
-        tc = mkTyCon3 packageName moduleName typeName
-        tr = mkTyConApp tc [getTyRep1 (undefined :: c ())]
-#endif

--- a/logic-TPTP.cabal
+++ b/logic-TPTP.cabal
@@ -60,7 +60,7 @@ Flag BuildTestPrograms
 Library
  ghc-options: -Wall -O2
 
- build-depends:      base >=4 && < 5
+ build-depends:      base >=4.8.0.0 && < 5
                    , array
                    , syb
                    , containers
@@ -101,8 +101,6 @@ Executable TestImportExportImportFile
                   , optparse-applicative >=0.11 && <0.19
                   , pcre-light
                   , semigroups
- if impl(ghc <7.10)
-  build-depends:    pcre-light <0.4.1
  default-language:  Haskell2010
  other-extensions:  CPP
  if !flag(BuildTestPrograms)
@@ -121,8 +119,6 @@ Test-suite TestImportExportRandom
                   , semigroups
                   , transformers
                   , transformers-compat >= 0.5
- if impl(ghc <7.10)
-  build-depends:    pcre-light <0.4.1
  default-language:  Haskell2010
  other-extensions:  CPP
 
@@ -142,8 +138,6 @@ Executable PrettyPrintFile
                   , QuickCheck
                   , semigroups
                   , syb
- if impl(ghc <7.10)
-  build-depends:    pcre-light <0.4.1
  default-language:  Haskell2010
  other-extensions:  CPP
  if !flag(BuildTestPrograms)
@@ -165,8 +159,6 @@ Executable ParseRandom
                   , QuickCheck
                   , semigroups
                   , syb
- if impl(ghc <7.10)
-  build-depends:    pcre-light <0.4.1
  default-language:  Haskell2010
  other-extensions:  CPP
  if !flag(BuildTestPrograms)

--- a/testing/Prof.hs
+++ b/testing/Prof.hs
@@ -5,7 +5,6 @@
  -XNamedFieldPuns
  -XRecordWildCards
  -XDeriveDataTypeable
- -XOverlappingInstances
  -fwarn-incomplete-patterns
  #-}
 

--- a/testing/SimpleArgs.hs
+++ b/testing/SimpleArgs.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, UndecidableInstances, OverlappingInstances #-}
+{-# LANGUAGE FlexibleInstances, UndecidableInstances #-}
 
 -- Copied and modified from https://hackage.haskell.org/package/simpleargs-0.2.1
 -- which is licensed under GNU LESSER GENERAL PUBLIC LICENSE Version 2.1


### PR DESCRIPTION
Note that per-instance pragmas are available since GHC 7.10

https://downloads.haskell.org/~ghc/7.10.1/docs/html/users_guide/type-class-extensions.html#instance-overlap