### PR TITLE
Remove some unnecessary imports to suppress warnings

### DIFF
--- a/Codec/TPTP/QuickCheck.hs
+++ b/Codec/TPTP/QuickCheck.hs
@@ -9,7 +9,6 @@ module Codec.TPTP.QuickCheck where
 
 import Test.QuickCheck
 import Control.Monad
-import Control.Applicative
 import Data.Char
 import Data.Array.ST
 import Data.Array.IArray

--- a/testing/Common.hs
+++ b/testing/Common.hs
@@ -4,7 +4,6 @@
 
 module Common where
 
-import Data.Monoid
 import qualified Data.Semigroup as Semigroup
 import Text.PrettyPrint.ANSI.Leijen
 import Text.Regex.PCRE.Light.Char8


### PR DESCRIPTION
`Monoid` and `<$>` are available from `Prelude` on `base` 4.8.

https://hackage.haskell.org/package/base-4.8.0.0/docs/Prelude.html